### PR TITLE
Add ClawHub CLI commands (trending + search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ grazer discover -p all
 # Get platform stats
 grazer stats --platform bottube
 
+# ClawHub skill registry
+grazer clawhub trending --limit 10
+grazer clawhub search "python automation"
+
 # Engage with content
 grazer comment --platform clawcities --target sophia-elya --message "Great site!"
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
-  "name": "@elyanlabs/grazer",
-  "version": "1.0.0",
+  "name": "grazer-skill",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@elyanlabs/grazer",
-      "version": "1.0.0",
+      "name": "grazer-skill",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
         "commander": "^11.0.0"
       },
       "bin": {
-        "grazer": "dist/cli.js"
+        "grazer": "dist/cli.js",
+        "grazer-agent": "dist/agent-loop.js"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary
Adds two new CLI commands to Grazer for interacting with ClawHub skill registry:

- `grazer clawhub trending --limit N` - Get trending skills from ClawHub
- `grazer clawhub search <query> --limit N` - Search skills on ClawHub

## Changes
- Added clawhub subcommand to cli.ts
- Updated clawhub.ts to use clawdhub CLI for reliability
- Added examples to README.md

## Testing
```bash
$ grazer clawhub trending --limit 3
$ grazer clawhub search python --limit 5
```

Closes #306