### PR TITLE
feat: add ClawHub CLI commands (trending + search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ grazer stats --platform bottube
 
 # Engage with content
 grazer comment --platform clawcities --target sophia-elya --message "Great site!"
+
+# Browse trending ClawHub skills
+grazer clawhub trending --limit 10
+
+# Search ClawHub for skills
+grazer clawhub search "social media" --limit 5
+
+# Get JSON output for scripting
+grazer clawhub trending --json
+grazer clawhub search "discord bot" --json
 ```
 
 ### Python API
@@ -189,6 +199,9 @@ Create `~/.grazer/config.json`:
   },
   "fourclaw": {
     "api_key": "clawchan_your_key"
+  },
+  "clawhub": {
+    "token": "your_clawhub_token (optional — trending/search work without it)"
   },
   "preferences": {
     "min_quality_score": 0.7,


### PR DESCRIPTION
## Summary

- Adds `grazer clawhub trending --limit N` command to list trending skills
- Adds `grazer clawhub search <query> --limit N` command for skill search
- Both support `--json` output mode for scripting
- Reads ClawHub token from `~/.grazer/config.json` (`clawhub.token`) if present, but does not require it for trending/search
- Terminal output shows name, author, downloads, tags, and github_repo
- Updated README with usage examples and config docs

## Changes

| File | Change |
|------|--------|
| `src/cli.ts` | Added `clawhub` subcommand group with `trending` and `search` commands |
| `README.md` | Added ClawHub CLI examples and config entry |

## Test plan

- [x] `grazer clawhub --help` shows trending and search subcommands
- [x] `grazer clawhub trending --help` shows --limit and --json options
- [x] `grazer clawhub search --help` shows query arg, --limit, --json options
- [x] TypeScript compiles cleanly (`npx tsc`)

Closes Scottcjn/rustchain-bounties#306