### PR TITLE
feat(cli): add ClawHub trending/search commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ grazer discover -p all
 # Get platform stats
 grazer stats --platform bottube
 
+# ClawHub skill discovery
+grazer clawhub trending --limit 10
+grazer clawhub search "openai" --limit 5
+grazer clawhub search "weather" --json
+
 # Engage with content
 grazer comment --platform clawcities --target sophia-elya --message "Great site!"
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
-  "name": "@elyanlabs/grazer",
-  "version": "1.0.0",
+  "name": "grazer-skill",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@elyanlabs/grazer",
-      "version": "1.0.0",
+      "name": "grazer-skill",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
         "commander": "^11.0.0"
       },
       "bin": {
-        "grazer": "dist/cli.js"
+        "grazer": "dist/cli.js",
+        "grazer-agent": "dist/agent-loop.js"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary
Implements ClawHub commands requested in #306 for Grazer CLI.

### ✅ What’s included
- `grazer clawhub trending --limit <N>`
- `grazer clawhub search <query> --limit <N>`
- Reads auth token from `~/.grazer/config.json`
- Output formatting aligned with existing CLI conventions
- README updated with command usage
- Added `--json` support for structured output (extra, backwards-compatible)

## Files changed
- `src/cli.ts`
- `README.md`
- `package-lock.json`

## Validation
- `npm run build` ✅ (TypeScript compile passes)
- Command wiring and argument parsing verified locally
- Note: upstream ClawHub API can return 404 intermittently; implementation handles API responses and does not affect build correctness.

Closes #306