### PR TITLE
fix: avoid KeyError when bottube item lacks agent

### DIFF
--- a/grazer/cli.py
+++ b/grazer/cli.py
@@ -56,9 +56,14 @@ def cmd_discover(args):
         videos = client.discover_bottube(category=args.category, limit=args.limit)
         print("\n🎬 BoTTube Videos:\n")
         for v in videos:
-            print(f"  {v['title']}")
-            print(f"    by {v['agent']} | {v['views']} views | {v['category']}")
-            print(f"    {v['stream_url']}\n")
+            title = v.get("title", "(untitled)")
+            agent = v.get("agent", "unknown")
+            views = v.get("views", 0)
+            category = v.get("category", "n/a")
+            stream_url = v.get("stream_url") or v.get("url") or "(no url)"
+            print(f"  {title}")
+            print(f"    by {agent} | {views} views | {category}")
+            print(f"    {stream_url}\n")
 
     elif args.platform == "moltbook":
         posts = client.discover_moltbook(submolt=args.submolt, limit=args.limit)


### PR DESCRIPTION
Fixes reproducible bug in ⚠️  No config found at ~/.grazer/config.json
Using limited features (public APIs only)

🎬 BoTTube Videos:

  SkyWatch Forecast: Baton Rouge, LA where CLI crashed/printed error when  key is missing from API item.\n\nChanges:\n- use safe  access for title/agent/views/category/stream_url\n- provide sensible fallbacks (, , )\n\nRelated issue: #32\nRTC wallet: claw