### PR TITLE
fix: add defensive .get() handling for all platform discover commands

### DIFF
--- a/grazer/cli.py
+++ b/grazer/cli.py
@@ -56,32 +56,32 @@ def cmd_discover(args):
         videos = client.discover_bottube(category=args.category, limit=args.limit)
         print("\n🎬 BoTTube Videos:\n")
         for v in videos:
-            print(f"  {v['title']}")
-            print(f"    by {v['agent']} | {v['views']} views | {v['category']}")
-            print(f"    {v['stream_url']}\n")
+            print(f"  {v.get('title', '?')}")
+            print(f"    by {v.get('agent', '?')} | {v.get('views', 0)} views | {v.get('category', '?')}")
+            print(f"    {v.get('stream_url', '')}\n")
 
     elif args.platform == "moltbook":
         posts = client.discover_moltbook(submolt=args.submolt, limit=args.limit)
         print("\n📚 Moltbook Posts:\n")
         for p in posts:
-            print(f"  {p['title']}")
-            print(f"    m/{p['submolt']} | {p.get('upvotes', 0)} upvotes")
-            print(f"    https://moltbook.com{p['url']}\n")
+            print(f"  {p.get('title', '(untitled)')}")
+            print(f"    m/{p.get('submolt', '?')} | {p.get('upvotes', 0)} upvotes")
+            print(f"    https://moltbook.com{p.get('url', '')}\n")
 
     elif args.platform == "clawcities":
         sites = client.discover_clawcities(limit=args.limit)
         print("\n🏙️ ClawCities Sites:\n")
         for s in sites:
-            print(f"  {s['display_name']}")
-            print(f"    {s['url']}\n")
+            print(f"  {s.get('display_name', '?')}")
+            print(f"    {s.get('url', '')}\n")
 
     elif args.platform == "clawsta":
         posts = client.discover_clawsta(limit=args.limit)
         print("\n🦞 Clawsta Posts:\n")
         for p in posts:
-            content = p["content"][:60] + "..." if len(p["content"]) > 60 else p["content"]
+            content = (p.get("content") or "")[:60] + "..." if len(p.get("content") or "") > 60 else (p.get("content") or "")
             print(f"  {content}")
-            print(f"    by {p['author']} | {p.get('likes', 0)} likes\n")
+            print(f"    by {p.get('author', '?')} | {p.get('likes', 0)} likes\n")
 
     elif args.platform == "fourclaw":
         board = args.board or "b"
@@ -92,13 +92,13 @@ def cmd_discover(args):
             replies = t.get("replyCount", 0)
             agent = t.get("agentName", "anon")
             print(f"  {title}")
-            print(f"    by {agent} | {replies} replies | id:{t['id'][:8]}\n")
+            print(f"    by {agent} | {replies} replies | id:{t.get('id', '?')[:8]}\n")
 
     elif args.platform == "pinchedin":
         posts = client.discover_pinchedin(limit=args.limit)
         print("\n💼 PinchedIn Feed:\n")
         for p in posts:
-            content = p["content"][:80] + "..." if len(p["content"]) > 80 else p["content"]
+            content = (p.get("content") or "")[:80] + "..." if len(p.get("content") or "") > 80 else (p.get("content") or "")
             author = p.get("author", {}).get("name", "?")
             print(f"  {content}")
             print(f"    by {author} | {p.get('likesCount', 0)} likes | {p.get('commentsCount', 0)} comments\n")
@@ -115,9 +115,9 @@ def cmd_discover(args):
         bounties = client.discover_clawtasks(limit=args.limit)
         print("\n🎯 ClawTasks Bounties:\n")
         for b in bounties:
-            print(f"  {b['title']}")
+            print(f"  {b.get('title', '?')}")
             tags = ", ".join(b.get("tags") or [])
-            print(f"    status: {b['status']} | tags: {tags} | deadline: {b.get('deadline_hours', '?')}h\n")
+            print(f"    status: {b.get('status', '?')} | tags: {tags} | deadline: {b.get('deadline_hours', '?')}h\n")
 
     elif args.platform == "clawnews":
         stories = client.discover_clawnews(limit=args.limit)


### PR DESCRIPTION
## Summary

Adds defensive .get() handling to all platform discover commands in the CLI to prevent crashes when API responses have missing fields.

## Changes

- BoTTube: use .get() for title, agent, views, category, stream_url
- Moltbook: use .get() for title, submolt, url
- ClawCities: use .get() for display_name, url
- Clawsta: use .get() for content, author (main fix from bounty #556)
- Fourclaw: use .get() for id
- Pinchedin: use .get() for content
- ClawTasks: use .get() for title, status

## Bounty

This PR addresses issue #556 - "Grazer: Defensive Error Handling Across All Platform Discover Methods" (5 RTC bounty)

Wallet: lustsazeus-lab