### PR TITLE
fix: defensive .get() handling across all platform discover methods

### DIFF
--- a/grazer/__init__.py
+++ b/grazer/__init__.py
@@ -128,7 +128,9 @@ class GrazerClient:
         videos = videos[: max(0, int(limit))]
         for v in videos:
             if "id" in v:
-                v["stream_url"] = f"https://bottube.ai/api/videos/{v['id']}/stream"
+                vid = v.get("id", "")
+                if vid:
+                    v["stream_url"] = f"https://bottube.ai/api/videos/{vid}/stream"
             # Normalize: API returns agent_name, consumers expect agent
             if "agent" not in v and "agent_name" in v:
                 v["agent"] = v["agent_name"]

--- a/grazer/cli.py
+++ b/grazer/cli.py
@@ -518,10 +518,10 @@ def cmd_status(args):
     print("\n📡 Platform Status:\n")
     up_count = 0
     for name, info in sorted(results.items()):
-        ok = info["ok"]
-        latency = info["latency_ms"]
+        ok = info.get("ok", False)
+        latency = info.get("latency_ms", 0)
         err = info.get("error")
-        auth = info["auth_configured"]
+        auth = info.get("auth_configured", False)
         status_icon = "UP" if ok else "DOWN"
         auth_icon = "key" if auth else "---"
         if ok:
@@ -879,13 +879,16 @@ def cmd_imagegen(args):
         template=getattr(args, "template", None),
         palette=getattr(args, "palette", None),
     )
-    print(f"\n🎨 SVG Generated ({result['method']}, {result['bytes']} bytes):\n")
+    method = result.get("method", "unknown")
+    nbytes = result.get("bytes", 0)
+    svg = result.get("svg", "")
+    print(f"\n🎨 SVG Generated ({method}, {nbytes} bytes):\n")
     if args.output:
         with open(args.output, "w") as f:
-            f.write(result["svg"])
+            f.write(svg)
         print(f"  Saved to: {args.output}")
     else:
-        print(result["svg"])
+        print(svg)
 
 
 def main():

--- a/tests/test_discover_defensive_all_platforms.py
+++ b/tests/test_discover_defensive_all_platforms.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+"""Additional defensive output tests for ALL remaining discover platforms.
+
+Covers: bottube, fourclaw, pinchedin, pinchedin-jobs, clawtasks, clawnews,
+and the status command — all with missing/None fields.
+"""
+import io
+import unittest
+from argparse import Namespace
+from contextlib import redirect_stdout
+from unittest.mock import Mock, patch
+
+from grazer import cli
+
+
+class DiscoverDefensiveAllPlatformsTests(unittest.TestCase):
+    def _run_discover(self, platform: str, client: Mock, board=None) -> str:
+        args = Namespace(
+            platform=platform,
+            category=None,
+            submolt="tech",
+            board=board,
+            limit=5,
+        )
+        with patch("grazer.cli.load_config", return_value={}):
+            with patch("grazer.cli._make_client", return_value=client):
+                output = io.StringIO()
+                with redirect_stdout(output):
+                    cli.cmd_discover(args)
+        return output.getvalue()
+
+    # --- BoTTube ---
+    def test_bottube_handles_missing_fields(self):
+        client = Mock()
+        client.discover_bottube.return_value = [{"views": 5}]
+        output = self._run_discover("bottube", client)
+        self.assertIn("(untitled)", output)
+        self.assertIn("unknown", output)  # agent default
+
+    def test_bottube_handles_none_values(self):
+        client = Mock()
+        client.discover_bottube.return_value = [
+            {"title": None, "agent": None, "views": None, "category": None, "stream_url": None, "url": None}
+        ]
+        output = self._run_discover("bottube", client)
+        self.assertIn("BoTTube", output)
+
+    # --- FourClaw ---
+    def test_fourclaw_handles_missing_fields(self):
+        client = Mock()
+        client.discover_fourclaw.return_value = [{"replyCount": 3}]
+        output = self._run_discover("fourclaw", client, board="b")
+        self.assertIn("(untitled)", output)
+        self.assertIn("anon", output)
+
+    def test_fourclaw_handles_none_id(self):
+        client = Mock()
+        client.discover_fourclaw.return_value = [{"title": "test", "id": None}]
+        output = self._run_discover("fourclaw", client, board="b")
+        self.assertIn("test", output)
+
+    # --- PinchedIn ---
+    def test_pinchedin_handles_missing_author(self):
+        client = Mock()
+        client.discover_pinchedin.return_value = [{"likesCount": 1, "commentsCount": 0}]
+        output = self._run_discover("pinchedin", client)
+        self.assertIn("(no content)", output)
+        self.assertIn("?", output)
+
+    def test_pinchedin_handles_empty_author_dict(self):
+        client = Mock()
+        client.discover_pinchedin.return_value = [{"content": "hello", "author": {}}]
+        output = self._run_discover("pinchedin", client)
+        self.assertIn("hello", output)
+
+    # --- PinchedIn Jobs ---
+    def test_pinchedin_jobs_handles_missing_fields(self):
+        client = Mock()
+        client.discover_pinchedin_jobs.return_value = [{"status": "open"}]
+        output = self._run_discover("pinchedin-jobs", client)
+        self.assertIn("?", output)
+        self.assertIn("open", output)
+
+    def test_pinchedin_jobs_handles_missing_poster(self):
+        client = Mock()
+        client.discover_pinchedin_jobs.return_value = [{"title": "Dev role", "poster": {}}]
+        output = self._run_discover("pinchedin-jobs", client)
+        self.assertIn("Dev role", output)
+
+    # --- ClawTasks ---
+    def test_clawtasks_handles_missing_fields(self):
+        client = Mock()
+        client.discover_clawtasks.return_value = [{"tags": None}]
+        output = self._run_discover("clawtasks", client)
+        self.assertIn("(untitled bounty)", output)
+
+    def test_clawtasks_handles_empty_tags(self):
+        client = Mock()
+        client.discover_clawtasks.return_value = [
+            {"title": "Fix bug", "tags": [], "status": None, "deadline_hours": None}
+        ]
+        output = self._run_discover("clawtasks", client)
+        self.assertIn("Fix bug", output)
+
+    # --- ClawNews ---
+    def test_clawnews_handles_missing_fields(self):
+        client = Mock()
+        client.discover_clawnews.return_value = [{}]
+        output = self._run_discover("clawnews", client)
+        self.assertIn("ClawNews", output)
+
+    def test_clawnews_handles_headline_fallback(self):
+        client = Mock()
+        client.discover_clawnews.return_value = [{"title": "Breaking news"}]
+        output = self._run_discover("clawnews", client)
+        self.assertIn("Breaking news", output)
+
+
+class StatusDefensiveTests(unittest.TestCase):
+    def test_status_handles_missing_fields(self):
+        client = Mock()
+        client.platform_status.return_value = {
+            "bottube": {"ok": True, "latency_ms": 50, "auth_configured": False},
+            "broken": {},  # Missing all fields
+        }
+        args = Namespace(platform="all")
+        with patch("grazer.cli.load_config", return_value={}):
+            with patch("grazer.cli._make_client", return_value=client):
+                output = io.StringIO()
+                with redirect_stdout(output):
+                    cli.cmd_status(args)
+        self.assertIn("bottube", output.getvalue())
+        self.assertIn("broken", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs Scottcjn/rustchain-bounties#556

## Changes
Replaces remaining direct dict access (`info["key"]`) with defensive `.get("key", default)` across all platform discover methods and the status command.

### Fixed
- `cmd_status`: `info["ok"]`, `info["latency_ms"]`, `info["auth_configured"]`
- `cmd_imagegen`: `result["method"]`, `result["bytes"]`, `result["svg"]`
- `__init__.py`: `v["id"]` in BoTTube stream URL generation

### Tests Added (13 new)
| Platform | Tests | Scenarios |
|---|---|---|
| BoTTube | 2 | Missing fields, None values |
| FourClaw | 2 | Missing fields, None id |
| PinchedIn | 2 | Missing author, empty author dict |
| PinchedIn Jobs | 2 | Missing fields, missing poster |
| ClawTasks | 2 | Missing fields, empty/None tags |
| ClawNews | 2 | Missing fields, headline fallback |
| Status | 1 | Missing fields in platform info |

```
19 passed in 0.32s (6 existing + 13 new)
```

Follows the pattern established in grazer-skill#35.

**BCOS-L1**

**Wallet:** will provide on acceptance