### PR TITLE
fix(cli): harden remaining discover output edge-cases

### DIFF
--- a/grazer/cli.py
+++ b/grazer/cli.py
@@ -145,18 +145,30 @@ def cmd_discover(args):
         print("\n💼 PinchedIn Feed:\n")
         for p in posts:
             content = _truncate(p.get("content"), 80, default="(no content)")
-            author = p.get("author", {}).get("name", "?")
+            author_data = p.get("author")
+            if isinstance(author_data, dict):
+                author = _to_text(author_data.get("name"), default="?")
+            else:
+                author = _to_text(author_data, default="?")
+            likes = p.get("likesCount", 0)
+            comments = p.get("commentsCount", 0)
             print(f"  {content}")
-            print(f"    by {author} | {p.get('likesCount', 0)} likes | {p.get('commentsCount', 0)} comments\n")
+            print(f"    by {author} | {likes} likes | {comments} comments\n")
 
     elif args.platform == "pinchedin-jobs":
         jobs = client.discover_pinchedin_jobs(limit=args.limit)
         jobs = jobs[:args.limit]
         print("\n💼 PinchedIn Jobs:\n")
         for j in jobs:
-            print(f"  {j.get('title', '?')}")
-            poster = j.get("poster", {}).get("name", "?")
-            print(f"    by {poster} | status: {j.get('status', '?')}\n")
+            title = _to_text(j.get("title"), default="?")
+            poster_data = j.get("poster")
+            if isinstance(poster_data, dict):
+                poster = _to_text(poster_data.get("name"), default="?")
+            else:
+                poster = _to_text(poster_data, default="?")
+            status = _to_text(j.get("status"), default="?")
+            print(f"  {title}")
+            print(f"    by {poster} | status: {status}\n")
 
     elif args.platform == "clawtasks":
         bounties = client.discover_clawtasks(limit=args.limit)
@@ -164,10 +176,17 @@ def cmd_discover(args):
         print("\n🎯 ClawTasks Bounties:\n")
         for b in bounties:
             title = _to_text(b.get("title"), default="(untitled bounty)")
-            tags = ", ".join(b.get("tags") or [])
+            tags_data = b.get("tags")
+            if isinstance(tags_data, list):
+                tags = ", ".join(_to_text(tag) for tag in tags_data)
+            elif tags_data is None:
+                tags = ""
+            else:
+                tags = _to_text(tags_data)
             status = _to_text(b.get("status"), default="unknown")
+            deadline_hours = _to_text(b.get("deadline_hours"), default="?")
             print(f"  {title}")
-            print(f"    status: {status} | tags: {tags} | deadline: {b.get('deadline_hours', '?')}h\n")
+            print(f"    status: {status} | tags: {tags} | deadline: {deadline_hours}h\n")
 
     elif args.platform == "clawnews":
         stories = client.discover_clawnews(limit=args.limit)

--- a/tests/test_discover_defensive_output.py
+++ b/tests/test_discover_defensive_output.py
@@ -69,6 +69,33 @@ class DiscoverDefensiveOutputTests(unittest.TestCase):
         output = self._run_discover("moltexchange", client)
         self.assertIn("by bot-1", output)
 
+    def test_pinchedin_handles_non_dict_author(self):
+        client = Mock()
+        client.discover_pinchedin.return_value = [
+            {"content": "test post", "author": "agent-42", "likesCount": 2, "commentsCount": 1}
+        ]
+        output = self._run_discover("pinchedin", client)
+        self.assertIn("by agent-42", output)
+        self.assertIn("2 likes", output)
+
+    def test_pinchedin_jobs_handles_non_dict_poster(self):
+        client = Mock()
+        client.discover_pinchedin_jobs.return_value = [
+            {"title": "Backend role", "poster": "team-alpha", "status": None}
+        ]
+        output = self._run_discover("pinchedin-jobs", client)
+        self.assertIn("by team-alpha", output)
+        self.assertIn("status: ?", output)
+
+    def test_clawtasks_handles_non_list_tags(self):
+        client = Mock()
+        client.discover_clawtasks.return_value = [
+            {"title": "Bounty A", "tags": "security", "status": "open", "deadline_hours": None}
+        ]
+        output = self._run_discover("clawtasks", client)
+        self.assertIn("tags: security", output)
+        self.assertIn("deadline: ?h", output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up hardening for issue #556 scope (defensive discover output handling).

### What this changes
- `pinchedin`: handle non-dict `author` safely (string/null/object)
- `pinchedin-jobs`: handle non-dict `poster` safely
- `clawtasks`: handle non-list `tags` safely and normalize `deadline_hours`

### Why
Some platform responses can return mixed types; these paths could still raise attribute errors (for example calling `.get` on a string). This patch keeps discover output resilient and aligned with the defensive `.get(..., default)` pattern.

### Tests
Added discover output regression tests:
- `test_pinchedin_handles_non_dict_author`
- `test_pinchedin_jobs_handles_non_dict_poster`
- `test_clawtasks_handles_non_list_tags`

Local validation:

```bash
python3 -m unittest discover -s tests -p "test_*.py" -v
# Ran 9 tests, all passing
```

Refs: #556
