### PR TITLE
feat(cli): add idempotency key support for post/comment

### DIFF
--- a/grazer/cli.py
+++ b/grazer/cli.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import sys
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -91,6 +92,57 @@ def _print_dry_run_preview(provider: str, payload: dict, text_value: Optional[st
         print(f"  media: {json.dumps(media_meta, ensure_ascii=False)}")
     print("  payload:")
     print(json.dumps(safe_payload, indent=2, ensure_ascii=False))
+
+
+DEFAULT_IDEMPOTENCY_TTL = 24 * 60 * 60
+
+
+def _idempotency_cache_path() -> Path:
+    return Path.home() / ".grazer" / "idempotency_keys.json"
+
+
+def _load_idempotency_cache(path: Optional[Path] = None) -> dict:
+    cache_path = path or _idempotency_cache_path()
+    if not cache_path.exists():
+        return {}
+    try:
+        data = json.loads(cache_path.read_text())
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _save_idempotency_cache(cache: dict, path: Optional[Path] = None) -> None:
+    cache_path = path or _idempotency_cache_path()
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps(cache, indent=2, sort_keys=True))
+
+
+def _cleanup_idempotency_cache(cache: dict, ttl_seconds: int, now_ts: Optional[float] = None) -> dict:
+    now = time.time() if now_ts is None else now_ts
+    cleaned = {}
+    for key, ts in cache.items():
+        if isinstance(ts, (int, float)) and (now - ts) <= ttl_seconds:
+            cleaned[key] = ts
+    return cleaned
+
+
+def _idempotency_is_duplicate(scope: str, key: Optional[str], ttl_seconds: int) -> bool:
+    if not key:
+        return False
+    cache = _load_idempotency_cache()
+    cache = _cleanup_idempotency_cache(cache, ttl_seconds)
+    _save_idempotency_cache(cache)
+    return f"{scope}:{key}" in cache
+
+
+def _idempotency_mark(scope: str, key: Optional[str], ttl_seconds: int) -> None:
+    if not key:
+        return
+    cache = _load_idempotency_cache()
+    cache = _cleanup_idempotency_cache(cache, ttl_seconds)
+    cache[f"{scope}:{key}"] = time.time()
+    _save_idempotency_cache(cache)
 
 
 def cmd_discover(args):
@@ -364,31 +416,49 @@ def cmd_comment(args):
         pinchedin_key=config.get("pinchedin", {}).get("api_key"),
     )
 
+    key = getattr(args, "idempotency_key", None)
+    ttl_seconds = int(getattr(args, "idempotency_ttl", DEFAULT_IDEMPOTENCY_TTL))
+
     if args.platform == "clawcities":
+        scope = f"comment:clawcities:{args.target or ''}"
         payload = {"site_name": args.target, "body": args.message}
         if getattr(args, "dry_run", False):
             _print_dry_run_preview("clawcities", payload, text_value=args.message)
             return
+        if _idempotency_is_duplicate(scope, key, ttl_seconds):
+            print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+            return
         result = client.comment_clawcities(args.target, args.message)
+        _idempotency_mark(scope, key, ttl_seconds)
         print(f"\n✓ Comment posted to {args.target}")
         print(f"  ID: {result.get('comment', {}).get('id')}")
 
     elif args.platform == "clawsta":
+        scope = "comment:clawsta"
         payload = {"content": args.message, "imageUrl": "https://bottube.ai/static/og-banner.png"}
         if getattr(args, "dry_run", False):
             _print_dry_run_preview("clawsta", payload, text_value=args.message, media_meta={"kind": "image", "source": "default_og_banner"})
             return
+        if _idempotency_is_duplicate(scope, key, ttl_seconds):
+            print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+            return
         result = client.post_clawsta(args.message)
+        _idempotency_mark(scope, key, ttl_seconds)
         print(f"\n✓ Posted to Clawsta")
         print(f"  ID: {result.get('id')}")
 
     elif args.platform == "pinchedin":
         if args.target:
+            scope = f"comment:pinchedin:{args.target}"
             payload = {"post_id": args.target, "content": args.message}
             if getattr(args, "dry_run", False):
                 _print_dry_run_preview("pinchedin", payload, text_value=args.message)
                 return
+            if _idempotency_is_duplicate(scope, key, ttl_seconds):
+                print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+                return
             result = client.comment_pinchedin(args.target, args.message)
+            _idempotency_mark(scope, key, ttl_seconds)
             print(f"\n✓ Comment posted on PinchedIn post {args.target[:8]}...")
             print(f"  ID: {result.get('id', 'ok')}")
         else:
@@ -397,11 +467,16 @@ def cmd_comment(args):
 
     elif args.platform == "fourclaw":
         if args.target:
+            scope = f"comment:fourclaw:{args.target}"
             payload = {"thread_id": args.target, "content": args.message}
             if getattr(args, "dry_run", False):
                 _print_dry_run_preview("fourclaw", payload, text_value=args.message)
                 return
+            if _idempotency_is_duplicate(scope, key, ttl_seconds):
+                print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+                return
             result = client.reply_fourclaw(args.target, args.message)
+            _idempotency_mark(scope, key, ttl_seconds)
             print(f"\n✓ Reply posted to thread {args.target[:8]}...")
             print(f"  ID: {result.get('reply', {}).get('id', 'ok')}")
         else:
@@ -410,11 +485,16 @@ def cmd_comment(args):
 
     elif args.platform == "thecolony":
         if args.target:
+            scope = f"comment:thecolony:{args.target}"
             payload = {"post_id": args.target, "content": args.message}
             if getattr(args, "dry_run", False):
                 _print_dry_run_preview("thecolony", payload, text_value=args.message)
                 return
+            if _idempotency_is_duplicate(scope, key, ttl_seconds):
+                print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+                return
             result = client.reply_colony(args.target, args.message)
+            _idempotency_mark(scope, key, ttl_seconds)
             print(f"\n✓ Reply posted to Colony post {args.target[:8]}...")
             print(f"  ID: {result.get('id', 'ok')}")
         else:
@@ -444,10 +524,14 @@ def cmd_post(args):
         **llm_cfg,
     )
 
+    key = getattr(args, "idempotency_key", None)
+    ttl_seconds = int(getattr(args, "idempotency_ttl", DEFAULT_IDEMPOTENCY_TTL))
+
     if args.platform == "fourclaw":
         if not args.board:
             print("Error: --board required for 4claw (e.g. b, singularity, crypto)")
             sys.exit(1)
+        scope = f"post:fourclaw:{args.board}:{args.title}"
         image_prompt = getattr(args, "image", None)
         template = getattr(args, "template", None)
         palette = getattr(args, "palette", None)
@@ -463,10 +547,14 @@ def cmd_post(args):
         if getattr(args, "dry_run", False):
             _print_dry_run_preview("fourclaw", payload, text_value=args.message, media_meta=media_meta)
             return
+        if _idempotency_is_duplicate(scope, key, ttl_seconds):
+            print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+            return
         result = client.post_fourclaw(
             args.board, args.title, args.message,
             image_prompt=image_prompt, template=template, palette=palette,
         )
+        _idempotency_mark(scope, key, ttl_seconds)
         thread = result.get("thread", {})
         print(f"\n✓ Thread created on /{args.board}/")
         print(f"  Title: {thread.get('title')}")
@@ -475,40 +563,60 @@ def cmd_post(args):
             print(f"  Image: generated from '{image_prompt}'")
 
     elif args.platform == "moltbook":
+        scope = f"post:moltbook:{args.board or 'tech'}:{args.title}"
         payload = {"title": args.title, "content": args.message, "submolt_name": args.board or "tech"}
         if getattr(args, "dry_run", False):
             _print_dry_run_preview("moltbook", payload, text_value=args.message)
             return
+        if _idempotency_is_duplicate(scope, key, ttl_seconds):
+            print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+            return
         result = client.post_moltbook(args.message, args.title, submolt=args.board or "tech")
+        _idempotency_mark(scope, key, ttl_seconds)
         print(f"\n✓ Posted to m/{args.board or 'tech'}")
         print(f"  ID: {result.get('id', 'ok')}")
 
     elif args.platform == "pinchedin":
+        scope = f"post:pinchedin:{args.title}"
         payload = {"content": args.message}
         if getattr(args, "dry_run", False):
             _print_dry_run_preview("pinchedin", payload, text_value=args.message)
             return
+        if _idempotency_is_duplicate(scope, key, ttl_seconds):
+            print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+            return
         result = client.post_pinchedin(args.message)
+        _idempotency_mark(scope, key, ttl_seconds)
         print(f"\n✓ Posted to PinchedIn")
         print(f"  ID: {result.get('id', 'ok')}")
 
     elif args.platform == "clawtasks":
+        scope = f"post:clawtasks:{args.title}"
         tags = args.board.split(",") if args.board else None
         payload = {"title": args.title, "description": args.message, "tags": tags}
         if getattr(args, "dry_run", False):
             _print_dry_run_preview("clawtasks", payload, text_value=args.message)
             return
+        if _idempotency_is_duplicate(scope, key, ttl_seconds):
+            print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+            return
         result = client.post_clawtask(args.title, args.message, tags=tags)
+        _idempotency_mark(scope, key, ttl_seconds)
         print(f"\n✓ Bounty posted on ClawTasks")
         print(f"  ID: {result.get('id', 'ok')}")
 
     elif args.platform == "agentchan":
         board = args.board or "ai"
+        scope = f"post:agentchan:{board}:{args.title}"
         payload = {"board": board, "content": args.message}
         if getattr(args, "dry_run", False):
             _print_dry_run_preview("agentchan", payload, text_value=args.message)
             return
+        if _idempotency_is_duplicate(scope, key, ttl_seconds):
+            print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+            return
         result = client.post_agentchan(board=board, content=args.message)
+        _idempotency_mark(scope, key, ttl_seconds)
         if result:
             print(f"\n✓ Thread posted on AgentChan /{board}/")
             print(f"  ID: {result.get('data', {}).get('id', result.get('id', 'ok'))}")
@@ -517,30 +625,45 @@ def cmd_post(args):
 
     elif args.platform == "thecolony":
         colony = args.board or "general"
+        scope = f"post:thecolony:{colony}:{args.title}"
         payload = {"colony": colony, "body": args.message}
         if getattr(args, "dry_run", False):
             _print_dry_run_preview("thecolony", payload, text_value=args.message)
             return
+        if _idempotency_is_duplicate(scope, key, ttl_seconds):
+            print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+            return
         result = client.post_colony(colony, args.message)
+        _idempotency_mark(scope, key, ttl_seconds)
         print(f"\n✓ Posted to c/{colony} on The Colony")
         print(f"  ID: {result.get('id', 'ok')}")
 
     elif args.platform == "moltx":
+        scope = f"post:moltx:{args.title}"
         payload = {"content": args.message}
         if getattr(args, "dry_run", False):
             _print_dry_run_preview("moltx", payload, text_value=args.message)
             return
+        if _idempotency_is_duplicate(scope, key, ttl_seconds):
+            print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+            return
         result = client.post_moltx(args.message)
+        _idempotency_mark(scope, key, ttl_seconds)
         print(f"\n✓ Posted to MoltX")
         print(f"  ID: {result.get('id', 'ok')}")
 
     elif args.platform == "moltexchange":
+        scope = f"post:moltexchange:{args.title}"
         tags = args.board.split(",") if args.board else None
         payload = {"title": args.title, "content": args.message, "tags": tags}
         if getattr(args, "dry_run", False):
             _print_dry_run_preview("moltexchange", payload, text_value=args.message)
             return
+        if _idempotency_is_duplicate(scope, key, ttl_seconds):
+            print(f"\n⚠️  Idempotency hit: skipped duplicate send (key={key})")
+            return
         result = client.post_moltexchange(args.title, args.message, tags=tags)
+        _idempotency_mark(scope, key, ttl_seconds)
         print(f"\n✓ Question posted on MoltExchange")
         print(f"  ID: {result.get('id', 'ok')}")
 
@@ -672,6 +795,8 @@ def main():
     comment_parser.add_argument("-t", "--target", help="Target (site name, post/thread ID)")
     comment_parser.add_argument("-m", "--message", required=True, help="Comment message")
     comment_parser.add_argument("--dry-run", action="store_true", help="Preview normalized payload without publishing")
+    comment_parser.add_argument("--idempotency-key", help="Skip duplicate sends for same key within TTL window")
+    comment_parser.add_argument("--idempotency-ttl", type=int, default=DEFAULT_IDEMPOTENCY_TTL, help="Idempotency key TTL in seconds (default: 86400)")
 
     # post command
     post_parser = subparsers.add_parser("post", help="Create a new post or thread")
@@ -688,6 +813,8 @@ def main():
     post_parser.add_argument("--template", help="SVG template: circuit, wave, grid, badge, terminal")
     post_parser.add_argument("--palette", help="Color palette: tech, crypto, retro, nature, dark, fire, ocean")
     post_parser.add_argument("--dry-run", action="store_true", help="Preview normalized payload without publishing")
+    post_parser.add_argument("--idempotency-key", help="Skip duplicate sends for same key within TTL window")
+    post_parser.add_argument("--idempotency-ttl", type=int, default=DEFAULT_IDEMPOTENCY_TTL, help="Idempotency key TTL in seconds (default: 86400)")
 
     # clawhub command
     clawhub_parser = subparsers.add_parser("clawhub", help="ClawHub skill registry")

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,60 @@
+import io
+import unittest
+from argparse import Namespace
+from contextlib import redirect_stdout
+from unittest.mock import Mock, patch
+
+from grazer import cli
+
+
+class IdempotencyTests(unittest.TestCase):
+    def test_comment_duplicate_key_skips_publish(self):
+        args = Namespace(
+            platform="pinchedin",
+            target="post-abc",
+            message="hello",
+            idempotency_key="k1",
+            idempotency_ttl=86400,
+        )
+        fake_client = Mock()
+
+        with patch("grazer.cli.load_config", return_value={}):
+            with patch("grazer.cli.GrazerClient", return_value=fake_client):
+                with patch("grazer.cli._idempotency_is_duplicate", return_value=True):
+                    out = io.StringIO()
+                    with redirect_stdout(out):
+                        cli.cmd_comment(args)
+
+        output = out.getvalue()
+        self.assertIn("Idempotency hit", output)
+        fake_client.comment_pinchedin.assert_not_called()
+
+    def test_post_new_key_marks_after_publish(self):
+        args = Namespace(
+            platform="pinchedin",
+            board=None,
+            title="Title",
+            message="Message",
+            image=None,
+            template=None,
+            palette=None,
+            idempotency_key="k2",
+            idempotency_ttl=86400,
+        )
+        fake_client = Mock()
+        fake_client.post_pinchedin.return_value = {"id": "123"}
+
+        with patch("grazer.cli.load_config", return_value={}):
+            with patch("grazer.cli.GrazerClient", return_value=fake_client):
+                with patch("grazer.cli._idempotency_is_duplicate", return_value=False):
+                    with patch("grazer.cli._idempotency_mark") as mark_mock:
+                        out = io.StringIO()
+                        with redirect_stdout(out):
+                            cli.cmd_post(args)
+
+        fake_client.post_pinchedin.assert_called_once_with("Message")
+        mark_mock.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Rebased replacement for #65 after #62 and #63 merged.

This PR contains the same idempotency-key feature and is conflict-free on current `main`.

## Included
- `--idempotency-key` for `grazer post` and `grazer comment`
- `--idempotency-ttl` (default 86400)
- Duplicate-send cache with TTL cleanup (`~/.grazer/idempotency_keys.json`)
- Tests in `tests/test_idempotency.py`

## Validation
`python3 -m unittest discover -s tests -p "test_*.py" -v` (14 passed)

Supersedes #65 (which is now out-of-date/conflicted).
