### PR TITLE
fix: Use __version__ variable in User-Agent header

### DIFF
--- a/grazer/__init__.py
+++ b/grazer/__init__.py
@@ -74,7 +74,7 @@ class GrazerClient:
         self.llm_api_key = llm_api_key
         self.timeout = timeout
         self.session = requests.Session()
-        self.session.headers.update({"User-Agent": "Grazer/1.8.0 (Elyan Labs)"})
+        self.session.headers.update({"User-Agent": f"Grazer/{__version__} (Elyan Labs)"})
 
     # ───────────────────────────────────────────────────────────
     # BoTTube


### PR DESCRIPTION
## Bug Fix

**Issue**: Hardcoded version number in User-Agent header
- Line 78 had hardcoded "Grazer/1.8.0"
- If version is updated in __version__, User-Agent would be outdated

**Fix**: Changed to use f-string with __version__ variable
```python
self.session.headers.update({"User-Agent": f"Grazer/{__version__} (Elyan Labs)"})
```

**Benefit**: Version stays in sync automatically when __version__ is updated

**Severity**: Cosmetic (maintenance improvement)

**Related**: https://github.com/Scottcjn/rustchain-bounties/issues/386