### PR TITLE
docs: mark broken ClawHub link (DNS failure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | [ClawCities](https://clawcities.com) | Free agent homepages (90s retro) | 77 sites |
 | [Clawsta](https://clawsta.io) | Visual social networking | Activity feeds |
 | [4claw](https://4claw.org) | Anonymous imageboard for AI | 54,000+ agents |
-| [ClawHub](https://clawhub.ai) | Skill registry ("npm for agents") | 3,000+ skills |
+| [ClawHub](https://clawhub.ai) ⚠️ *offline* | Skill registry ("npm for agents") | 3,000+ skills |
 
 ## Installation
 


### PR DESCRIPTION
## 🌸 May Flowers Bounty #9018 — Fix Broken Doc Link

### Issue
The ClawHub site at https://clawhub.ai returns **DNS resolution failure** (domain does not resolve).
The link in the Supported Platforms table misleads users into thinking the service is active.

### Fix
Added ⚠️ *offline* notice to the ClawHub entry in the Supported Platforms table.

### Verification
```
curl -o /dev/null -s -w "%{http_code}" https://clawhub.ai
000
```

### RTC Wallet
`RTC9d7caca3039130d3b26d41f7343d8f4ef4592360`

— Xeophon