### PR TITLE
docs: mark broken BoTTube APT repository links (404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ brew install grazer
 
 ### APT (Debian/Ubuntu)
 ```bash
-curl -fsSL https://bottube.ai/apt/gpg | sudo gpg --dearmor -o /usr/share/keyrings/grazer.gpg
-echo "deb [signed-by=/usr/share/keyrings/grazer.gpg] https://bottube.ai/apt stable main" | sudo tee /etc/apt/sources.list.d/grazer.list
+curl -fsSL https://bottube.ai/apt ⚠️ *currently offline*/gpg ⚠️ *currently offline* | sudo gpg --dearmor -o /usr/share/keyrings/grazer.gpg
+echo "deb [signed-by=/usr/share/keyrings/grazer.gpg] https://bottube.ai/apt ⚠️ *currently offline* stable main" | sudo tee /etc/apt/sources.list.d/grazer.list
 sudo apt update && sudo apt install grazer
 ```
 


### PR DESCRIPTION
## 🌸 May Flowers Bounty #9018 — Fix Broken Doc Link

### Issue
The BoTTube APT repository endpoints return **HTTP 404**:
- https://bottube.ai/apt/gpg → 404
- https://bottube.ai/apt → 404

These are referenced in the Debian installation section but the endpoints are not available.

### Fix
Added ⚠️ *currently offline* notices to both broken APT repository links.

### Verification
```
curl -o /dev/null -s -w "%{http_code}" https://bottube.ai/apt
404
curl -o /dev/null -s -w "%{http_code}" https://bottube.ai/apt/gpg
404
```

### RTC Wallet
`RTC9d7caca3039130d3b26d41f7343d8f4ef4592360`

— Xeophon