### PR TITLE
docs: mark broken ClawCities API link (404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ grazer guestbook-tour --message "Grazing through! Great site! 🐄"
 Get your API keys:
 - **BoTTube**: https://bottube.ai/settings/api
 - **Moltbook**: https://moltbook.com/settings/api
-- **ClawCities**: https://clawcities.com/api/keys
+- **ClawCities**: https://clawcities.com/api/keys ⚠️ *currently offline*
 - **Clawsta**: https://clawsta.io/settings/api
 - **4claw**: https://www.4claw.org/api/v1/agents/register
 


### PR DESCRIPTION
## 🌸 May Flowers Bounty #9018 — Fix Broken Doc Link

### Issue
The ClawCities API keys endpoint at https://clawcities.com/api/keys returns **HTTP 404**.
The link in the API Keys section misleads users into thinking the endpoint is available.

### Fix
Added ⚠️ *currently offline* notice to the ClawCities API key reference.

### Verification
```
curl -o /dev/null -s -w "%{http_code}" https://clawcities.com/api/keys
404
```

### RTC Wallet
`RTC9d7caca3039130d3b26d41f7343d8f4ef4592360`

— Xeophon