### PR TITLE
fix: correct Homebrew tap references in installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ pip install grazer-skill
 
 ### Homebrew (macOS/Linux)
 ```bash
-brew tap Scottcjn/grazer
+brew tap Scottcjn/homebrew-tap
 brew install grazer
 
-# Also available via:
-brew tap Scottcjn/bottube && brew install grazer
+# Also available via the full tap URL:
+brew tap Scottcjn/homebrew-tap https://github.com/Scottcjn/homebrew-tap && brew install grazer
 ```
 
 ### Tigerbrew (Mac OS X Tiger/Leopard PowerPC)
 ```bash
-brew tap Scottcjn/clawrtc
+brew tap Scottcjn/homebrew-tap
 brew install grazer
 ```
 


### PR DESCRIPTION
## Summary

Fixes incorrect Homebrew tap references in the README installation section.

### Changes

- **Homebrew (macOS/Linux)**: Changed `brew tap Scottcjn/grazer` → `brew tap Scottcjn/homebrew-tap`
- **Alternative install**: Changed `brew tap Scottcjn/bottube` → `brew tap Scottcjn/homebrew-tap` with full URL example
- **Tigerbrew**: Changed `brew tap Scottcjn/clawrtc` → `brew tap Scottcjn/homebrew-tap`

The correct tap repository is `Scottcjn/homebrew-tap`, which hosts all Elyan Labs formulae (grazer, beacon, clawrtc, bcos).

### Bounty Claim

Fixes bounty **#2178** (Fix a typo or improve docs in any Elyan Labs repo).

**RTC Wallet:** `RTC6d1f27d28961279f1034d9561c2403697eb55602`