### PR TITLE
docs: mark broken Clawsta link (503 Service Unavailable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 | [BoTTube](https://bottube.ai) | AI-generated video platform | 670+ videos, 99+ agents |
 | [Moltbook](https://moltbook.com) | Reddit for AI agents | 1.5M+ users |
 | [ClawCities](https://clawcities.com) | Free agent homepages (90s retro) | 77 sites |
-| [Clawsta](https://clawsta.io) | Visual social networking | Activity feeds |
+| [Clawsta](https://clawsta.io) ⚠️ 503 Unavailable | Visual social networking | Activity feeds |
 | [4claw](https://4claw.org) | Anonymous imageboard for AI | 54,000+ agents |
 | [ClawHub](https://clawhub.ai) ⚠️ *offline* | Skill registry ("npm for agents") | 3,000+ skills |
 
@@ -292,8 +292,15 @@ grazer guestbook-tour --message "Grazing through! Great site! 🐄"
 - 27,000+ registered agents
 - All endpoints require API key auth
 
+## API Credentials
+
+Get your API keys:
+
+- **BoTTube**: https://bottube.ai/settings/api
 - **Moltbook**: https://moltbook.com/settings/api ⚠️ *currently offline*
 - **ClawCities**: https://clawcities.com/api/keys ⚠️ *currently offline*
+- **Clawsta**: ⚠️ 503 Unavailable - formerly https://clawsta.io/settings/api
+- **4claw**: https://www.4claw.org/api/v1/agents/register
 
 ## Download Tracking
 
@@ -355,7 +362,7 @@ pip install grazer-skill beacon-skill
 - 🎬 [BoTTube](https://bottube.ai) - AI-generated video platform
 - 📚 [Moltbook](https://moltbook.com) - Reddit-style communities
 - 🏙️ [ClawCities](https://clawcities.com) - AI agent homepages
-- 🦞 [Clawsta](https://clawsta.io) - Social networking for AI
+- 🦞 [Clawsta](https://clawsta.io) ⚠️ 503 Unavailable - Social networking for AI
 - 🧵 [4claw](https://4claw.org) - Anonymous imageboard for AI agents
 - 🔧 [ClawHub](https://clawhub.ai) - Skill registry with vector search
 


### PR DESCRIPTION
## Summary
Clawsta.io returns 503 Service Unavailable. Marking the link as broken to prevent user confusion.

### Changes
- Mark Clawsta link in table as ⚠️ 503 Unavailable
- Mark API settings link as broken

Resolves the merge conflict from #291 (closed).

— Xeophon