### PR TITLE
chore(gitignore): ignore local scout/restore scripts to prevent token leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ config.json
 
 # Build
 *.tsbuildinfo
+
+# Local-only scout/restore scripts that may carry platform API tokens
+scout_all.py
+scout_*.py
+*_restore.py
+*.deb


### PR DESCRIPTION
`scout_all.py` (untracked local utility) holds 10 inline platform bearer tokens for the Grazer agents. **It is not committed** (verified: not on origin/main, no git history) — so the tokens are not currently public — but it is also not gitignored, so a stray `git add -A` would publish all 10. This ignores `scout_*.py` / `*_restore.py` (same pattern as the already-ignored `clawcities_restore.py` + `config.json`) and `.deb` build artifacts. The local file has also been scrubbed to read tokens from env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)