### PR TITLE
feat: expose discovery platform health metadata

### DIFF
--- a/grazer/__init__.py
+++ b/grazer/__init__.py
@@ -7,7 +7,7 @@ import requests
 import threading
 import time as _time
 from typing import List, Dict, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 from grazer.imagegen import generate_svg, svg_to_media, generate_template_svg, generate_llm_svg
 from grazer.clawhub import ClawHubClient
@@ -1300,6 +1300,52 @@ class GrazerClient:
 
         return results
 
+    def _discovery_health_entry(self, platform: str, status: Optional[Dict], last_checked_at: str) -> Dict:
+        """Normalize platform_status output for machine-readable discovery results."""
+        status = status or {}
+        error = status.get("error")
+        http_status = status.get("status_code")
+        ok = bool(status.get("ok"))
+
+        if ok and not error:
+            availability = "ok"
+        elif ok:
+            availability = "degraded"
+        elif http_status and http_status >= 500:
+            availability = "unavailable"
+        elif error in {"timeout", "connection_refused"}:
+            availability = "unavailable"
+        elif error == "unknown_platform":
+            availability = "unknown"
+        else:
+            availability = "unavailable" if error else "unknown"
+
+        if not error:
+            error_type = None
+        elif error == "unknown_platform":
+            error_type = "unknown_platform"
+        elif error in {"timeout", "connection_refused"}:
+            error_type = error
+        elif isinstance(error, str) and error.startswith("HTTP "):
+            error_type = "http_error"
+        else:
+            error_type = "exception"
+
+        entry = {
+            "platform": platform,
+            "status": availability,
+            "last_checked_at": last_checked_at,
+            "fresh": True,
+            "cached": False,
+            "error_type": error_type,
+            "auth_configured": bool(status.get("auth_configured")),
+        }
+        if http_status is not None:
+            entry["http_status"] = http_status
+        if "latency_ms" in status:
+            entry["latency_ms"] = status.get("latency_ms")
+        return entry
+
     def _has_auth(self, platform: str) -> bool:
         """Check if authentication is configured for a platform."""
         mapping = {
@@ -1506,13 +1552,14 @@ class GrazerClient:
     # Cross-Platform
     # ───────────────────────────────────────────────────────────
 
-    def discover_all(self, limit: int = 10) -> Dict[str, List[Dict]]:
+    def discover_all(self, limit: int = 10, include_health: bool = False) -> Dict[str, List[Dict]]:
         """Discover content from all platforms.
 
         Returns a dict keyed by platform name. Also includes an ``_errors``
         key mapping platform names to error strings for any platform that
         failed during discovery, so callers can distinguish "no content"
-        from "platform unreachable".
+        from "platform unreachable". When include_health=True, also includes
+        ``_health`` with machine-readable platform status metadata.
         """
         results: Dict = {
             "bottube": [],
@@ -1565,11 +1612,36 @@ class GrazerClient:
             ("nostr",         lambda: self.discover_nostr(limit=limit)),
         ]
 
+        if include_health:
+            platform_names = [name for name, _ in calls]
+            last_checked_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+            try:
+                health = self.platform_status(platform_names)
+            except Exception as exc:
+                health = {
+                    name: {
+                        "ok": False,
+                        "error": str(exc)[:80],
+                        "auth_configured": self._has_auth(name),
+                    }
+                    for name in platform_names
+                }
+            results["_health"] = {
+                name: self._discovery_health_entry(name, health.get(name), last_checked_at)
+                for name in platform_names
+            }
+
         for name, fn in calls:
             try:
                 results[name] = fn()
             except Exception as exc:
                 results["_errors"][name] = str(exc)[:120]
+                if include_health and name in results.get("_health", {}):
+                    health_entry = results["_health"][name]
+                    if health_entry["status"] == "ok":
+                        health_entry["status"] = "degraded"
+                    if not health_entry.get("error_type"):
+                        health_entry["error_type"] = "discovery_error"
 
         return results
 

--- a/grazer/cli.py
+++ b/grazer/cli.py
@@ -470,8 +470,10 @@ def cmd_discover(args):
             print(f"    {url}\n")
 
     elif args.platform == "all":
-        all_content = client.discover_all(limit=args.limit)
+        include_health = getattr(args, "include_health", False)
+        all_content = client.discover_all(limit=args.limit, include_health=include_health)
         errors = all_content.pop("_errors", {})
+        health = all_content.pop("_health", {})
         print("\n🌐 All Platforms:\n")
         labels = {
             "bottube": "BoTTube videos",
@@ -500,10 +502,16 @@ def cmd_discover(args):
         for key, label in labels.items():
             count = len(all_content.get(key, []))
             err = errors.get(key)
+            health_suffix = ""
+            if include_health:
+                platform_health = health.get(key, {})
+                status = platform_health.get("status", "unknown")
+                source = "cached" if platform_health.get("cached") else "fresh" if platform_health.get("fresh") else "unknown"
+                health_suffix = f" [{status}, {source}]"
             if err:
-                print(f"  {label}: OFFLINE ({err[:60]})")
+                print(f"  {label}: OFFLINE{health_suffix} ({err[:60]})")
             else:
-                print(f"  {label}: {count}")
+                print(f"  {label}: {count}{health_suffix}")
         print()
 
 
@@ -911,6 +919,7 @@ def main():
     discover_parser.add_argument("-s", "--submolt", help="Moltbook submolt", default="tech")
     discover_parser.add_argument("-b", "--board", help="4claw board (e.g. b, singularity, crypto)")
     discover_parser.add_argument("-l", "--limit", type=int, default=20, help="Result limit")
+    discover_parser.add_argument("--include-health", action="store_true", help="Include machine-readable platform health in all-platform discovery")
 
     # stats command
     stats_parser = subparsers.add_parser("stats", help="Get platform statistics")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -321,9 +321,94 @@ def test_discover_all_includes_new_platforms():
     assert len(result["arxiv"]) == 1
     assert len(result["youtube"]) == 1
     assert len(result["podcasts"]) == 1
+    assert "_health" not in result
+
+
+def test_discover_all_include_health_metadata():
+    """discover_all can include machine-readable platform health metadata."""
+    client = GrazerClient()
+    for method in [
+        "discover_bottube", "discover_moltbook", "discover_clawcities",
+        "discover_clawsta", "discover_fourclaw", "discover_pinchedin",
+        "discover_clawtasks", "discover_clawnews", "discover_directory",
+        "discover_agentchan", "discover_colony", "discover_moltx",
+        "discover_moltexchange", "discover_arxiv", "discover_youtube",
+        "discover_podcasts", "discover_bluesky", "discover_farcaster",
+        "discover_semantic_scholar", "discover_openreview", "discover_mastodon",
+        "discover_nostr",
+    ]:
+        setattr(client, method, Mock(return_value=[]))
+
+    with patch.object(
+        client,
+        "platform_status",
+        return_value={
+            "bottube": {
+                "ok": True,
+                "status_code": 200,
+                "latency_ms": 12.5,
+                "error": None,
+                "auth_configured": False,
+            },
+            "clawsta": {
+                "ok": False,
+                "status_code": 503,
+                "latency_ms": 200.0,
+                "error": "HTTP 503",
+                "auth_configured": False,
+            },
+        },
+    ) as mock_status:
+        result = client.discover_all(limit=5, include_health=True)
+
+    mock_status.assert_called_once()
+    health = result["_health"]
+    assert health["bottube"]["platform"] == "bottube"
+    assert health["bottube"]["status"] == "ok"
+    assert health["bottube"]["http_status"] == 200
+    assert health["bottube"]["fresh"] is True
+    assert health["bottube"]["cached"] is False
+    assert health["bottube"]["last_checked_at"].endswith("Z")
+    assert health["clawsta"]["status"] == "unavailable"
+    assert health["clawsta"]["error_type"] == "http_error"
+    assert health["clawsta"]["http_status"] == 503
 
 
 # ─── CLI Integration ───────────────────────────────────────
+
+
+def test_cli_discover_all_include_health_output():
+    """CLI discover --platform all can show platform health summaries."""
+    mock_client = Mock()
+    mock_client.discover_all.return_value = {
+        "bottube": [],
+        "_errors": {},
+        "_health": {
+            "bottube": {
+                "status": "ok",
+                "fresh": True,
+                "cached": False,
+            }
+        },
+    }
+
+    args = Namespace(
+        platform="all",
+        category=None,
+        submolt="tech",
+        board=None,
+        limit=5,
+        include_health=True,
+    )
+    with patch("grazer.cli.load_config", return_value={}):
+        with patch("grazer.cli._make_client", return_value=mock_client):
+            output = io.StringIO()
+            with redirect_stdout(output):
+                cli.cmd_discover(args)
+
+    text = output.getvalue()
+    mock_client.discover_all.assert_called_once_with(limit=5, include_health=True)
+    assert "BoTTube videos: 0 [ok, fresh]" in text
 
 
 def test_cli_discover_arxiv():


### PR DESCRIPTION
## Summary
- adds optional machine-readable platform health metadata to all-platform discovery output
- normalizes existing platform_status results into status, last_checked_at, error_type, http_status, fresh, and cached fields
- adds a CLI --include-health flag while preserving default discover output compatibility

Fixes #306

## Validation
- py -m py_compile grazer\\__init__.py grazer\\cli.py
- py -m pytest -q tests\\test_plugins.py
- py -m pytest -q tests\\test_discover_defensive_all_platforms.py tests\\test_discover_defensive_output.py
- py -m pytest -q tests\\test_bottube_grazer.py::TestGrazerClientIntegration::test_discover_all_includes_bottube tests\\test_new_plugins.py::test_client_discover_all_includes_new_platforms
- git diff --check

## Payout
If this bounty is accepted/merged, payout address: 0x255969B3265958Dc0B8db1082843d0e7E82cb62d