### PR TITLE
docs: fix APT install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ brew install grazer
 ```
 
 ### APT (Debian/Ubuntu)
+
+> **Status:** The APT repository is currently offline. These commands are
+> retained for use when the service is restored.
+
 ```bash
-curl -fsSL https://bottube.ai/apt ⚠️ *currently offline*/gpg ⚠️ *currently offline* | sudo gpg --dearmor -o /usr/share/keyrings/grazer.gpg
-echo "deb [signed-by=/usr/share/keyrings/grazer.gpg] https://bottube.ai/apt ⚠️ *currently offline* stable main" | sudo tee /etc/apt/sources.list.d/grazer.list
+curl -fsSL https://bottube.ai/apt/gpg | sudo gpg --dearmor -o /usr/share/keyrings/grazer.gpg
+echo "deb [signed-by=/usr/share/keyrings/grazer.gpg] https://bottube.ai/apt stable main" | sudo tee /etc/apt/sources.list.d/grazer.list
 sudo apt update && sudo apt install grazer
 ```
 


### PR DESCRIPTION
## Summary
- move the APT repository offline warning outside the executable code block
- restore the GPG URL to `/apt/gpg`
- remove status text from the `deb` source URL

## Why
The warning text was embedded in both shell commands, making the documented installation block invalid and unsafe to copy and paste.

## Validation
- verified the APT code block contains no status text or warning symbols
- verified the offline warning remains visible outside the executable block
- verified both restored APT URLs
- `git diff --check`

Fixes #312