### PR TITLE
Fix Windows Unicode console output and CLI version

### DIFF
--- a/grazer/cli.py
+++ b/grazer/cli.py
@@ -11,7 +11,22 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from grazer import GrazerClient, PLATFORMS
+from grazer import GrazerClient, PLATFORMS, __version__
+
+
+def _configure_console_encoding() -> None:
+    """Use UTF-8 for Grazer's Unicode CLI output on Windows."""
+    if os.name != "nt":
+        return
+
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            pass
 
 
 def load_config() -> dict:
@@ -900,10 +915,12 @@ def cmd_imagegen(args):
 
 
 def main():
+    _configure_console_encoding()
+
     parser = argparse.ArgumentParser(
         description="🐄 Grazer - Content discovery for AI agents"
     )
-    parser.add_argument("--version", action="version", version="grazer 1.9.1")
+    parser.add_argument("--version", action="version", version=f"grazer {__version__}")
 
     subparsers = parser.add_subparsers(dest="command", help="Commands")
 

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -1,0 +1,50 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from grazer import __version__, cli
+
+
+class ReconfigurableStream:
+    def __init__(self):
+        self.calls = []
+
+    def reconfigure(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+class CLIRuntimeTests(unittest.TestCase):
+    def test_version_matches_package_version(self):
+        output = io.StringIO()
+
+        with patch.object(cli.sys, "argv", ["grazer", "--version"]):
+            with redirect_stdout(output):
+                with self.assertRaises(SystemExit) as exit_context:
+                    cli.main()
+
+        self.assertEqual(exit_context.exception.code, 0)
+        self.assertEqual(output.getvalue().strip(), f"grazer {__version__}")
+
+    def test_windows_console_streams_are_configured_for_utf8(self):
+        stdout = ReconfigurableStream()
+        stderr = ReconfigurableStream()
+
+        with patch.object(cli.os, "name", "nt"):
+            with patch.object(cli.sys, "stdout", stdout):
+                with patch.object(cli.sys, "stderr", stderr):
+                    cli._configure_console_encoding()
+
+        expected = [{"encoding": "utf-8", "errors": "replace"}]
+        self.assertEqual(stdout.calls, expected)
+        self.assertEqual(stderr.calls, expected)
+
+    def test_console_configuration_allows_non_reconfigurable_streams(self):
+        with patch.object(cli.os, "name", "nt"):
+            with patch.object(cli.sys, "stdout", io.StringIO()):
+                with patch.object(cli.sys, "stderr", io.StringIO()):
+                    cli._configure_console_encoding()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- configure Windows stdout and stderr for UTF-8 before any Unicode CLI output
- derive `grazer --version` from the package version instead of a stale literal
- add regression coverage for version output and Windows stream configuration

## Validation
- `python -m pytest -q` (116 passed)
- `python -m grazer.cli --version` returns `grazer 2.0.1`
- live `discover --platform bottube --limit 1` succeeds on Windows without `PYTHONUTF8`

Fixes #315