### PR TITLE
Deduplicate cross-platform discoveries with canonical groups

### DIFF
--- a/grazer/__init__.py
+++ b/grazer/__init__.py
@@ -3,11 +3,16 @@ Grazer - Multi-Platform Content Discovery for AI Agents
 PyPI package for Python integration
 """
 
-import requests
+import hashlib
+import json
+import re
 import threading
 import time as _time
-from typing import List, Dict, Optional
 from datetime import datetime, timezone
+from typing import Any, List, Dict, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import requests
 
 from grazer.imagegen import generate_svg, svg_to_media, generate_template_svg, generate_llm_svg
 from grazer.clawhub import ClawHubClient
@@ -46,6 +51,163 @@ PLATFORMS = {
     "mastodon":     {"url": "https://mastodon.social/api/v1/",         "auth": False},
     "nostr":        {"url": "https://api.nostr.band/",                 "auth": False},
 }
+
+_TRACKING_QUERY_KEYS = {"fbclid", "gclid", "mc_cid", "mc_eid"}
+_URL_FIELDS = (
+    "canonical_url",
+    "source_url",
+    "url",
+    "external_url",
+    "stream_url",
+    "video_url",
+    "feed_url",
+    "pdf_url",
+)
+_CONTENT_FIELDS = (
+    "title",
+    "headline",
+    "name",
+    "subject",
+    "text",
+    "content",
+    "body",
+    "description",
+)
+_CREATOR_FIELDS = (
+    "author_username",
+    "author_name",
+    "author_acct",
+    "author",
+    "creator",
+    "channel",
+    "user",
+    "pubkey",
+)
+_TIMESTAMP_FIELDS = (
+    "published_at",
+    "created_at",
+    "timestamp",
+    "published",
+    "date",
+    "updated_at",
+)
+
+
+def _scalar_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, dict):
+        for key in ("username", "handle", "name", "id"):
+            text = _scalar_text(value.get(key))
+            if text:
+                return text
+        return ""
+    if isinstance(value, (list, tuple)):
+        return " ".join(filter(None, (_scalar_text(item) for item in value)))
+    return str(value).strip()
+
+
+def _normalize_identity_text(value: Any) -> str:
+    text = _scalar_text(value).casefold()
+    return re.sub(r"\W+", " ", text, flags=re.UNICODE).strip()
+
+
+def _normalize_source_url(value: Any) -> str:
+    raw = _scalar_text(value)
+    if not raw:
+        return ""
+
+    try:
+        parts = urlsplit(raw)
+    except ValueError:
+        return ""
+    if parts.scheme.casefold() not in {"http", "https"} or not parts.netloc:
+        return ""
+
+    host = parts.hostname.casefold() if parts.hostname else ""
+    if host.startswith("www."):
+        host = host[4:]
+    try:
+        port = parts.port
+    except ValueError:
+        return ""
+    if port and not (
+        (parts.scheme.casefold() == "http" and port == 80)
+        or (parts.scheme.casefold() == "https" and port == 443)
+    ):
+        host = f"{host}:{port}"
+
+    path = re.sub(r"/+", "/", parts.path or "/")
+    if path != "/":
+        path = path.rstrip("/")
+    query = urlencode(
+        sorted(
+            (key, query_value)
+            for key, query_value in parse_qsl(parts.query, keep_blank_values=True)
+            if not key.casefold().startswith("utm_")
+            and key.casefold() not in _TRACKING_QUERY_KEYS
+        )
+    )
+    return urlunsplit((parts.scheme.casefold(), host, path, query, ""))
+
+
+def _timestamp_bucket(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(value, timezone.utc).date().isoformat()
+        except (OSError, OverflowError, ValueError):
+            return ""
+
+    text = _scalar_text(value)
+    match = re.match(r"^\d{4}-\d{2}-\d{2}", text)
+    return match.group(0) if match else ""
+
+
+def _canonical_source_keys(platform: str, item: Dict) -> List[str]:
+    keys: List[str] = []
+
+    for field in _URL_FIELDS:
+        normalized_url = _normalize_source_url(item.get(field))
+        if normalized_url:
+            digest = hashlib.sha256(normalized_url.encode("utf-8")).hexdigest()[:24]
+            keys.append(f"url:{digest}")
+            break
+
+    content = next(
+        (
+            normalized
+            for field in _CONTENT_FIELDS
+            if (normalized := _normalize_identity_text(item.get(field)))
+        ),
+        "",
+    )
+    creator = next(
+        (
+            normalized
+            for field in _CREATOR_FIELDS
+            if (normalized := _normalize_identity_text(item.get(field)))
+        ),
+        "",
+    )
+    bucket = next(
+        (
+            normalized
+            for field in _TIMESTAMP_FIELDS
+            if (normalized := _timestamp_bucket(item.get(field)))
+        ),
+        "",
+    )
+    if content and (creator or bucket):
+        identity = "\n".join((content, creator, bucket))
+        digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:24]
+        keys.append(f"content:{digest}")
+
+    if not keys:
+        stable_item = json.dumps(item, sort_keys=True, default=str, separators=(",", ":"))
+        digest = hashlib.sha256(stable_item.encode("utf-8")).hexdigest()[:24]
+        keys.append(f"item:{platform}:{digest}")
+
+    return keys
 
 
 class ThreadSafeRateLimiter:
@@ -1552,14 +1714,71 @@ class GrazerClient:
     # Cross-Platform
     # ───────────────────────────────────────────────────────────
 
-    def discover_all(self, limit: int = 10, include_health: bool = False) -> Dict[str, List[Dict]]:
+    @staticmethod
+    def deduplicate_discoveries(results: Dict[str, List[Dict]]) -> List[Dict]:
+        """Group cross-platform observations that share a canonical source."""
+        groups: List[Dict] = []
+        groups_by_key: Dict[str, Dict] = {}
+
+        for platform, items in results.items():
+            if platform.startswith("_") or not isinstance(items, list):
+                continue
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+
+                keys = _canonical_source_keys(platform, item)
+                matching_groups: List[Dict] = []
+                for key in keys:
+                    group = groups_by_key.get(key)
+                    if group is not None and all(
+                        group is not known for known in matching_groups
+                    ):
+                        matching_groups.append(group)
+
+                if matching_groups:
+                    group = matching_groups[0]
+                    for duplicate_group in matching_groups[1:]:
+                        group["variants"].extend(duplicate_group["variants"])
+                        for observed in duplicate_group["observed_platforms"]:
+                            if observed not in group["observed_platforms"]:
+                                group["observed_platforms"].append(observed)
+                        for known_key, known_group in list(groups_by_key.items()):
+                            if known_group is duplicate_group:
+                                groups_by_key[known_key] = group
+                        groups.remove(duplicate_group)
+                else:
+                    group = {
+                        "canonical_key": keys[0],
+                        "canonical": {"platform": platform, "item": item},
+                        "observed_platforms": [],
+                        "variants": [],
+                    }
+                    groups.append(group)
+
+                if platform not in group["observed_platforms"]:
+                    group["observed_platforms"].append(platform)
+                group["variants"].append({"platform": platform, "item": item})
+                for key in keys:
+                    groups_by_key[key] = group
+
+        return groups
+
+    def discover_all(
+        self,
+        limit: int = 10,
+        include_health: bool = False,
+        deduplicate: bool = False,
+    ) -> Dict[str, List[Dict]]:
         """Discover content from all platforms.
 
         Returns a dict keyed by platform name. Also includes an ``_errors``
         key mapping platform names to error strings for any platform that
         failed during discovery, so callers can distinguish "no content"
         from "platform unreachable". When include_health=True, also includes
-        ``_health`` with machine-readable platform status metadata.
+        ``_health`` with machine-readable platform status metadata. When
+        deduplicate=True, ``_canonical`` groups matching observations while
+        preserving every platform variant.
         """
         results: Dict = {
             "bottube": [],
@@ -1642,6 +1861,9 @@ class GrazerClient:
                         health_entry["status"] = "degraded"
                     if not health_entry.get("error_type"):
                         health_entry["error_type"] = "discovery_error"
+
+        if deduplicate:
+            results["_canonical"] = self.deduplicate_discoveries(results)
 
         return results
 

--- a/grazer/cli.py
+++ b/grazer/cli.py
@@ -471,9 +471,17 @@ def cmd_discover(args):
 
     elif args.platform == "all":
         include_health = getattr(args, "include_health", False)
-        all_content = client.discover_all(limit=args.limit, include_health=include_health)
+        deduplicate = getattr(args, "deduplicate", False)
+        discover_options = {
+            "limit": args.limit,
+            "include_health": include_health,
+        }
+        if deduplicate:
+            discover_options["deduplicate"] = True
+        all_content = client.discover_all(**discover_options)
         errors = all_content.pop("_errors", {})
         health = all_content.pop("_health", {})
+        canonical = all_content.pop("_canonical", [])
         print("\n🌐 All Platforms:\n")
         labels = {
             "bottube": "BoTTube videos",
@@ -512,6 +520,10 @@ def cmd_discover(args):
                 print(f"  {label}: OFFLINE{health_suffix} ({err[:60]})")
             else:
                 print(f"  {label}: {count}{health_suffix}")
+        if deduplicate:
+            observations = sum(len(group.get("variants", [])) for group in canonical)
+            collapsed = max(0, observations - len(canonical))
+            print(f"  Canonical items: {len(canonical)} ({collapsed} duplicate observations collapsed)")
         print()
 
 
@@ -920,6 +932,7 @@ def main():
     discover_parser.add_argument("-b", "--board", help="4claw board (e.g. b, singularity, crypto)")
     discover_parser.add_argument("-l", "--limit", type=int, default=20, help="Result limit")
     discover_parser.add_argument("--include-health", action="store_true", help="Include machine-readable platform health in all-platform discovery")
+    discover_parser.add_argument("--deduplicate", action="store_true", help="Group matching cross-platform observations")
 
     # stats command
     stats_parser = subparsers.add_parser("stats", help="Get platform statistics")

--- a/tests/test_discovery_deduplication.py
+++ b/tests/test_discovery_deduplication.py
@@ -1,0 +1,169 @@
+import io
+from argparse import Namespace
+from contextlib import redirect_stdout
+from unittest.mock import Mock, patch
+
+from grazer import GrazerClient
+from grazer import cli
+
+
+def test_deduplicate_discoveries_normalizes_tracking_urls():
+    results = {
+        "bottube": [
+            {
+                "title": "A shared item",
+                "url": "https://www.example.com/watch/42/?utm_source=bottube",
+            }
+        ],
+        "moltbook": [
+            {
+                "title": "A shared item",
+                "url": "https://example.com/watch/42?fbclid=tracking",
+            }
+        ],
+        "_errors": {},
+    }
+
+    groups = GrazerClient.deduplicate_discoveries(results)
+
+    assert len(groups) == 1
+    assert groups[0]["observed_platforms"] == ["bottube", "moltbook"]
+    assert len(groups[0]["variants"]) == 2
+    assert groups[0]["canonical"]["platform"] == "bottube"
+
+
+def test_deduplicate_discoveries_matches_mirrors_by_content_identity():
+    results = {
+        "clawnews": [
+            {
+                "headline": "RustChain releases indexed UTXO pagination",
+                "author": {"username": "alice"},
+                "created_at": "2026-06-12T01:15:00Z",
+                "url": "https://news.example/posts/100",
+            }
+        ],
+        "moltbook": [
+            {
+                "title": "RustChain releases indexed UTXO pagination",
+                "author_name": "Alice",
+                "timestamp": "2026-06-12T09:45:00Z",
+                "url": "https://social.example/thread/abc",
+            }
+        ],
+    }
+
+    groups = GrazerClient.deduplicate_discoveries(results)
+
+    assert len(groups) == 1
+    assert len(groups[0]["variants"]) == 2
+
+
+def test_deduplicate_discoveries_keeps_ambiguous_titles_separate():
+    results = {
+        "bottube": [{"title": "Daily update"}],
+        "moltbook": [{"title": "Daily update"}],
+    }
+
+    groups = GrazerClient.deduplicate_discoveries(results)
+
+    assert len(groups) == 2
+
+
+def test_deduplicate_discoveries_tolerates_invalid_url_ports():
+    results = {
+        "bottube": [
+            {
+                "title": "Port parsing should not abort discovery",
+                "url": "https://example.com:not-a-port/watch",
+            }
+        ]
+    }
+
+    groups = GrazerClient.deduplicate_discoveries(results)
+
+    assert len(groups) == 1
+
+
+def test_discover_all_only_adds_canonical_output_when_requested():
+    client = GrazerClient()
+    methods = [
+        "discover_bottube",
+        "discover_moltbook",
+        "discover_clawcities",
+        "discover_clawsta",
+        "discover_fourclaw",
+        "discover_pinchedin",
+        "discover_clawtasks",
+        "discover_clawnews",
+        "discover_directory",
+        "discover_agentchan",
+        "discover_colony",
+        "discover_moltx",
+        "discover_moltexchange",
+        "discover_arxiv",
+        "discover_youtube",
+        "discover_podcasts",
+        "discover_bluesky",
+        "discover_farcaster",
+        "discover_semantic_scholar",
+        "discover_openreview",
+        "discover_mastodon",
+        "discover_nostr",
+    ]
+    for method in methods:
+        setattr(client, method, Mock(return_value=[]))
+    client.discover_bottube = Mock(
+        return_value=[{"title": "Shared", "author": "alice"}]
+    )
+    client.discover_moltbook = Mock(
+        return_value=[{"title": "Shared", "author": "alice"}]
+    )
+
+    regular = client.discover_all(limit=1)
+    deduplicated = client.discover_all(limit=1, deduplicate=True)
+
+    assert "_canonical" not in regular
+    assert len(deduplicated["_canonical"]) == 1
+    assert len(deduplicated["_canonical"][0]["variants"]) == 2
+
+
+def test_cli_reports_collapsed_observations():
+    mock_client = Mock()
+    mock_client.discover_all.return_value = {
+        "bottube": [{"title": "Shared"}],
+        "moltbook": [{"title": "Shared"}],
+        "_errors": {},
+        "_canonical": [
+            {
+                "canonical_key": "content:key",
+                "canonical": {"platform": "bottube", "item": {"title": "Shared"}},
+                "observed_platforms": ["bottube", "moltbook"],
+                "variants": [
+                    {"platform": "bottube", "item": {"title": "Shared"}},
+                    {"platform": "moltbook", "item": {"title": "Shared"}},
+                ],
+            }
+        ],
+    }
+    args = Namespace(
+        platform="all",
+        category=None,
+        submolt="tech",
+        board=None,
+        limit=5,
+        include_health=False,
+        deduplicate=True,
+    )
+
+    with patch("grazer.cli.load_config", return_value={}):
+        with patch("grazer.cli._make_client", return_value=mock_client):
+            output = io.StringIO()
+            with redirect_stdout(output):
+                cli.cmd_discover(args)
+
+    mock_client.discover_all.assert_called_once_with(
+        limit=5,
+        include_health=False,
+        deduplicate=True,
+    )
+    assert "Canonical items: 1 (1 duplicate observations collapsed)" in output.getvalue()


### PR DESCRIPTION
## Summary
- add deterministic source keys from normalized URLs and content identity
- expose `GrazerClient.deduplicate_discoveries()` while preserving every platform variant
- add opt-in `discover_all(..., deduplicate=True)` output under `_canonical`
- add `grazer discover --platform all --deduplicate` summary output

The existing per-platform result shape is unchanged unless deduplication is explicitly requested.

## Validation
- `python -m pytest -q` (119 passed)
- `python -m grazer.cli discover --help` exposes `--deduplicate`
- `git diff --check`

Fixes #313