### PR TITLE
Add JSON, CSV, and Markdown discovery exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ grazer post --platform fourclaw --board singularity --title "Hello" --message "C
 # Browse trending ClawHub skills
 grazer clawhub trending --limit 10
 
+# Export discovery results for analysis
+grazer discover --platform moltbook --limit 20 --export-json output.json
+grazer discover --platform bottube --limit 50 --export-csv videos.csv
+grazer discover --platform all --export-md content-report.md
+
 # Search ClawHub for skills
 grazer clawhub search "social media" --limit 5
 

--- a/grazer/cli.py
+++ b/grazer/cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Optional
 
 from grazer import GrazerClient, PLATFORMS, __version__
+from grazer.export import export_discovery
 
 
 def _configure_console_encoding() -> None:
@@ -160,6 +161,19 @@ def _idempotency_mark(scope: str, key: Optional[str], ttl_seconds: int) -> None:
     _save_idempotency_cache(cache)
 
 
+def _maybe_export(args, data) -> None:
+    exports = (
+        ("json", getattr(args, "export_json", None)),
+        ("csv", getattr(args, "export_csv", None)),
+        ("md", getattr(args, "export_md", None)),
+    )
+    for export_format, output in exports:
+        if output:
+            count = export_discovery(args.platform, data, export_format, output)
+            print(f"Exported {count} items to {Path(output).expanduser()}")
+            return
+
+
 def cmd_discover(args):
     """Discover trending content."""
     config = load_config()
@@ -168,6 +182,7 @@ def cmd_discover(args):
     if args.platform == "bottube":
         videos = client.discover_bottube(category=args.category, limit=args.limit)
         videos = videos[:args.limit]
+        _maybe_export(args, videos)
         print("\n🎬 BoTTube Videos:\n")
         for v in videos:
             title = v.get("title", "(untitled)")
@@ -182,6 +197,7 @@ def cmd_discover(args):
     elif args.platform == "moltbook":
         posts = client.discover_moltbook(submolt=args.submolt, limit=args.limit)
         posts = posts[:args.limit]
+        _maybe_export(args, posts)
         print("\n📚 Moltbook Posts:\n")
         for p in posts:
             title = _to_text(p.get("title"), default="(untitled)")
@@ -201,6 +217,7 @@ def cmd_discover(args):
     elif args.platform == "clawcities":
         sites = client.discover_clawcities(limit=args.limit)
         sites = sites[:args.limit]
+        _maybe_export(args, sites)
         print("\n🏙️ ClawCities Sites:\n")
         for s in sites:
             display_name = _to_text(s.get("display_name"), default=_to_text(s.get("name"), default="(unnamed site)"))
@@ -211,6 +228,7 @@ def cmd_discover(args):
     elif args.platform == "clawsta":
         posts = client.discover_clawsta(limit=args.limit)
         posts = posts[:args.limit]
+        _maybe_export(args, posts)
         print("\n🦞 Clawsta Posts:\n")
         for p in posts:
             content = _truncate(p.get("content"), 60, default="(no content)")
@@ -227,6 +245,7 @@ def cmd_discover(args):
         board = args.board or "b"
         threads = client.discover_fourclaw(board=board, limit=args.limit, include_content=True)
         threads = threads[:args.limit]
+        _maybe_export(args, threads)
         print(f"\n🦞 4claw /{board}/:\n")
         for t in threads:
             title = t.get("title", "(untitled)")
@@ -239,6 +258,7 @@ def cmd_discover(args):
     elif args.platform == "pinchedin":
         posts = client.discover_pinchedin(limit=args.limit)
         posts = posts[:args.limit]
+        _maybe_export(args, posts)
         print("\n💼 PinchedIn Feed:\n")
         for p in posts:
             content = _truncate(p.get("content"), 80, default="(no content)")
@@ -255,6 +275,7 @@ def cmd_discover(args):
     elif args.platform == "pinchedin-jobs":
         jobs = client.discover_pinchedin_jobs(limit=args.limit)
         jobs = jobs[:args.limit]
+        _maybe_export(args, jobs)
         print("\n💼 PinchedIn Jobs:\n")
         for j in jobs:
             title = _to_text(j.get("title"), default="?")
@@ -270,6 +291,7 @@ def cmd_discover(args):
     elif args.platform == "clawtasks":
         bounties = client.discover_clawtasks(limit=args.limit)
         bounties = bounties[:args.limit]
+        _maybe_export(args, bounties)
         print("\n🎯 ClawTasks Bounties:\n")
         for b in bounties:
             title = _to_text(b.get("title"), default="(untitled bounty)")
@@ -288,6 +310,7 @@ def cmd_discover(args):
     elif args.platform == "clawnews":
         stories = client.discover_clawnews(limit=args.limit)
         stories = stories[:args.limit]
+        _maybe_export(args, stories)
         print("\n📰 ClawNews Stories:\n")
         for s in stories:
             title = s.get("headline", s.get("title", "?"))
@@ -298,6 +321,7 @@ def cmd_discover(args):
         board = args.board or "ai"
         threads = client.discover_agentchan(board=board, limit=args.limit)
         threads = threads[:args.limit]
+        _maybe_export(args, threads)
         print(f"\n🤖 AgentChan /{board}/:\n")
         for t in threads:
             subject = t.get("subject", t.get("title", "(untitled)"))
@@ -310,6 +334,7 @@ def cmd_discover(args):
         colony = args.board or None
         posts = client.discover_colony(colony=colony, limit=args.limit)
         posts = posts[:args.limit]
+        _maybe_export(args, posts)
         label = f"c/{colony}" if colony else "all"
         print(f"\n🏰 The Colony {label}:\n")
         for p in posts:
@@ -326,6 +351,7 @@ def cmd_discover(args):
     elif args.platform == "moltx":
         posts = client.discover_moltx(limit=args.limit)
         posts = posts[:args.limit]
+        _maybe_export(args, posts)
         print("\n📱 MoltX Feed:\n")
         for p in posts:
             content = _truncate(p.get("content"), 80, default="(no content)")
@@ -338,6 +364,7 @@ def cmd_discover(args):
     elif args.platform == "moltexchange":
         questions = client.discover_moltexchange(limit=args.limit)
         questions = questions[:args.limit]
+        _maybe_export(args, questions)
         print("\n🔄 MoltExchange Questions:\n")
         for q in questions:
             title = _to_text(q.get("title"), default=_truncate(q.get("content"), 60, default="?"))
@@ -354,6 +381,7 @@ def cmd_discover(args):
         query = getattr(args, "category", None) or "AI"
         papers = client.discover_arxiv(query=query, limit=args.limit)
         papers = papers[:args.limit]
+        _maybe_export(args, papers)
         print("\n📄 ArXiv Papers:\n")
         for p in papers:
             title = _to_text(p.get("title"), default="(untitled)")
@@ -372,6 +400,7 @@ def cmd_discover(args):
         query = getattr(args, "category", None) or "AI agents"
         videos = client.discover_youtube(query=query, limit=args.limit)
         videos = videos[:args.limit]
+        _maybe_export(args, videos)
         print("\n▶ YouTube Videos:\n")
         for v in videos:
             title = _to_text(v.get("title"), default="(untitled)")
@@ -387,6 +416,7 @@ def cmd_discover(args):
         query = getattr(args, "category", None) or "artificial intelligence"
         shows = client.discover_podcasts(query=query, limit=args.limit)
         shows = shows[:args.limit]
+        _maybe_export(args, shows)
         print("\n🎙 Podcasts:\n")
         for s in shows:
             name = _to_text(s.get("name"), default="(unnamed)")
@@ -402,6 +432,7 @@ def cmd_discover(args):
         query = getattr(args, "category", None) or "AI agents"
         posts = client.discover_bluesky(query=query, limit=args.limit)
         posts = posts[:args.limit]
+        _maybe_export(args, posts)
         print("\n🦋 Bluesky Posts:\n")
         for p in posts:
             text = _truncate(p.get("text"), 80, default="(no content)")
@@ -416,6 +447,7 @@ def cmd_discover(args):
         query = getattr(args, "category", None) or "AI agents"
         casts = client.discover_farcaster(query=query, limit=args.limit)
         casts = casts[:args.limit]
+        _maybe_export(args, casts)
         print("\n🟪 Farcaster Casts:\n")
         for c in casts:
             text = _truncate(c.get("text"), 80, default="(no content)")
@@ -430,6 +462,7 @@ def cmd_discover(args):
         query = getattr(args, "category", None) or "large language models"
         papers = client.discover_semantic_scholar(query=query, limit=args.limit)
         papers = papers[:args.limit]
+        _maybe_export(args, papers)
         print("\n🎓 Semantic Scholar Papers:\n")
         for p in papers:
             title = _to_text(p.get("title"), default="(untitled)")
@@ -446,6 +479,7 @@ def cmd_discover(args):
         query = getattr(args, "category", None) or "large language models"
         papers = client.discover_openreview(query=query, limit=args.limit)
         papers = papers[:args.limit]
+        _maybe_export(args, papers)
         print("\n📋 OpenReview Papers:\n")
         for p in papers:
             title = _to_text(p.get("title"), default="(untitled)")
@@ -461,6 +495,7 @@ def cmd_discover(args):
         query = getattr(args, "category", None) or "AI"
         posts = client.discover_mastodon(query=query, limit=args.limit)
         posts = posts[:args.limit]
+        _maybe_export(args, posts)
         print("\n🐘 Mastodon Posts:\n")
         for p in posts:
             text = _truncate(p.get("text"), 80, default="(no content)")
@@ -475,6 +510,7 @@ def cmd_discover(args):
         query = getattr(args, "category", None) or "AI"
         events = client.discover_nostr(query=query, limit=args.limit)
         events = events[:args.limit]
+        _maybe_export(args, events)
         print("\n🔮 Nostr Events:\n")
         for e in events:
             content = _truncate(e.get("content"), 80, default="(no content)")
@@ -494,6 +530,7 @@ def cmd_discover(args):
         if deduplicate:
             discover_options["deduplicate"] = True
         all_content = client.discover_all(**discover_options)
+        _maybe_export(args, all_content)
         errors = all_content.pop("_errors", {})
         health = all_content.pop("_health", {})
         canonical = all_content.pop("_canonical", [])
@@ -950,6 +987,10 @@ def main():
     discover_parser.add_argument("-l", "--limit", type=int, default=20, help="Result limit")
     discover_parser.add_argument("--include-health", action="store_true", help="Include machine-readable platform health in all-platform discovery")
     discover_parser.add_argument("--deduplicate", action="store_true", help="Group matching cross-platform observations")
+    export_group = discover_parser.add_mutually_exclusive_group()
+    export_group.add_argument("--export-json", metavar="PATH", help="Export discovery results as JSON")
+    export_group.add_argument("--export-csv", metavar="PATH", help="Export discovery results as CSV")
+    export_group.add_argument("--export-md", metavar="PATH", help="Export discovery results as Markdown")
 
     # stats command
     stats_parser = subparsers.add_parser("stats", help="Get platform statistics")

--- a/grazer/export.py
+++ b/grazer/export.py
@@ -1,0 +1,150 @@
+"""Structured export helpers for Grazer discovery results."""
+
+import csv
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _platform_items(platform: str, data: Any) -> Iterable[Tuple[str, Dict[str, Any]]]:
+    if platform == "all" and isinstance(data, dict):
+        for name, items in data.items():
+            if name.startswith("_") or not isinstance(items, list):
+                continue
+            for item in items:
+                if isinstance(item, dict):
+                    yield name, item
+        return
+
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict):
+                yield platform, item
+
+
+def _serialize_cell(value: Any) -> Any:
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    if value is None:
+        return ""
+    return value
+
+
+def _export_payload(platform: str, data: Any) -> Dict[str, Any]:
+    discovered_at = _timestamp()
+    if platform == "all" and isinstance(data, dict):
+        platforms = {
+            name: items
+            for name, items in data.items()
+            if not name.startswith("_") and isinstance(items, list)
+        }
+        payload = {
+            "platform": platform,
+            "discovered_at": discovered_at,
+            "count": sum(len(items) for items in platforms.values()),
+            "platforms": platforms,
+        }
+        metadata = {
+            name.lstrip("_"): value
+            for name, value in data.items()
+            if name.startswith("_")
+        }
+        if metadata:
+            payload["metadata"] = metadata
+        return payload
+
+    items = data if isinstance(data, list) else []
+    return {
+        "platform": platform,
+        "discovered_at": discovered_at,
+        "count": len(items),
+        "items": items,
+    }
+
+
+def _write_json(path: Path, platform: str, data: Any) -> None:
+    path.write_text(
+        json.dumps(_export_payload(platform, data), indent=2, ensure_ascii=False)
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_csv(path: Path, platform: str, data: Any) -> None:
+    rows: List[Dict[str, Any]] = []
+    fields = {"platform"}
+    for item_platform, item in _platform_items(platform, data):
+        row = {"platform": item_platform}
+        row.update({key: _serialize_cell(value) for key, value in item.items()})
+        rows.append(row)
+        fields.update(row)
+
+    fieldnames = ["platform"] + sorted(fields - {"platform"})
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_markdown(path: Path, platform: str, data: Any) -> None:
+    payload = _export_payload(platform, data)
+    lines = [
+        "# Grazer Discovery Export",
+        "",
+        f"- Platform: `{platform}`",
+        f"- Discovered at: `{payload['discovered_at']}`",
+        f"- Items: {payload['count']}",
+        "",
+    ]
+
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for item_platform, item in _platform_items(platform, data):
+        grouped.setdefault(item_platform, []).append(item)
+
+    for name, items in grouped.items():
+        lines.extend([f"## {name}", ""])
+        for index, item in enumerate(items, start=1):
+            title = next(
+                (
+                    str(item[key]).strip()
+                    for key in ("title", "headline", "name", "subject", "text", "content")
+                    if item.get(key)
+                ),
+                f"Item {index}",
+            )
+            lines.extend(
+                [
+                    f"### {index}. {title}",
+                    "",
+                    "```json",
+                    json.dumps(item, indent=2, ensure_ascii=False, sort_keys=True),
+                    "```",
+                    "",
+                ]
+            )
+
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def export_discovery(platform: str, data: Any, export_format: str, output: str) -> int:
+    """Write discovery data and return the exported item count."""
+    path = Path(output).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if export_format == "json":
+        _write_json(path, platform, data)
+    elif export_format == "csv":
+        _write_csv(path, platform, data)
+    elif export_format == "md":
+        _write_markdown(path, platform, data)
+    else:
+        raise ValueError(f"Unsupported export format: {export_format}")
+
+    return sum(1 for _ in _platform_items(platform, data))

--- a/tests/test_discovery_export.py
+++ b/tests/test_discovery_export.py
@@ -1,0 +1,102 @@
+import csv
+import io
+import json
+from argparse import Namespace
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from grazer import cli
+from grazer.export import export_discovery
+
+
+def test_json_export_includes_metadata_and_items(tmp_path):
+    output = tmp_path / "results.json"
+    count = export_discovery(
+        "moltbook",
+        [{"title": "Post", "author": {"name": "Alice"}}],
+        "json",
+        str(output),
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert count == 1
+    assert payload["platform"] == "moltbook"
+    assert payload["count"] == 1
+    assert payload["discovered_at"].endswith("Z")
+    assert payload["items"][0]["author"]["name"] == "Alice"
+
+
+def test_csv_export_flattens_platforms_and_serializes_nested_values(tmp_path):
+    output = tmp_path / "results.csv"
+    data = {
+        "bottube": [{"title": "Video", "tags": ["ai", "bitcoin"]}],
+        "moltbook": [{"title": "Post", "author": {"name": "Alice"}}],
+        "_errors": {},
+    }
+
+    count = export_discovery("all", data, "csv", str(output))
+
+    with output.open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    assert count == 2
+    assert [row["platform"] for row in rows] == ["bottube", "moltbook"]
+    assert json.loads(rows[0]["tags"]) == ["ai", "bitcoin"]
+    assert json.loads(rows[1]["author"]) == {"name": "Alice"}
+
+
+def test_markdown_export_groups_all_platform_results(tmp_path):
+    output = tmp_path / "report.md"
+    export_discovery(
+        "all",
+        {
+            "bottube": [{"title": "Video"}],
+            "moltbook": [{"title": "Post"}],
+            "_errors": {},
+        },
+        "md",
+        str(output),
+    )
+
+    text = output.read_text(encoding="utf-8")
+    assert "# Grazer Discovery Export" in text
+    assert "## bottube" in text
+    assert "### 1. Video" in text
+    assert "## moltbook" in text
+
+
+def test_cli_bottube_export_keeps_normal_output(tmp_path):
+    output = tmp_path / "videos.json"
+    client = Mock()
+    client.discover_bottube.return_value = [
+        {"title": "Video", "agent_name": "Alice", "views": 3}
+    ]
+    args = Namespace(
+        platform="bottube",
+        category=None,
+        submolt="tech",
+        board=None,
+        limit=5,
+        include_health=False,
+        export_json=str(output),
+        export_csv=None,
+        export_md=None,
+    )
+
+    with patch("grazer.cli.load_config", return_value={}):
+        with patch("grazer.cli._make_client", return_value=client):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                cli.cmd_discover(args)
+
+    assert "Exported 1 items" in stdout.getvalue()
+    assert "BoTTube Videos" in stdout.getvalue()
+    assert json.loads(output.read_text(encoding="utf-8"))["count"] == 1
+
+
+def test_cli_export_flags_are_mutually_exclusive():
+    source = Path(cli.__file__).read_text(encoding="utf-8")
+    assert "add_mutually_exclusive_group()" in source
+    assert "--export-json" in source
+    assert "--export-csv" in source
+    assert "--export-md" in source


### PR DESCRIPTION
## Summary
- add opt-in `--export-json`, `--export-csv`, and `--export-md` paths to `grazer discover`
- preserve metadata and platform grouping in JSON and Markdown exports
- flatten cross-platform results for CSV while serializing nested values safely
- keep existing terminal output unchanged and document example commands

## Validation
- `python -m pytest -q` (118 passed)
- focused export tests (5 passed)
- live BoTTube export produced and re-parsed a two-item UTF-8 JSON file
- `git diff --check`

Fixes #29