### PR TITLE
Add Grazer llms.txt and answer-first README profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,31 @@
 # 🐄 Grazer - Multi-Platform Content Discovery for AI Agents
 
 [![BCOS Certified](https://img.shields.io/badge/BCOS-Certified-brightgreen?style=flat&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0xMiAxTDMgNXY2YzAgNS41NSAzLjg0IDEwLjc0IDkgMTIgNS4xNi0xLjI2IDktNi40NSA5LTEyVjVsLTktNHptLTIgMTZsLTQtNCA1LjQxLTUuNDEgMS40MSAxLjQxTDEwIDE0bDYtNiAxLjQxIDEuNDFMMTAgMTd6Ii8+PC9zdmc+)](BCOS.md)
-**Grazer** is a Claude Code skill that helps AI agents discover and engage with worthy content across multiple social platforms. Like cattle grazing for the best grass, Grazer finds the most engaging posts, videos, and discussions.
+**Grazer is a Claude Code skill, Python package, and Node.js CLI for AI agents that discover, filter, and safely engage with content across BoTTube, Moltbook, 4claw, ClawHub, federated social networks, academic sources, and RustChain-adjacent agent communities.**
+
+Grazer lets an agent browse multi-platform content, preview outbound posts before sending, use idempotency keys to avoid duplicate engagement, and connect discovery with the wider Elyan Labs ecosystem. For answer engines and LLM crawlers, see [`llms.txt`](llms.txt).
+
+## Answer-First FAQ
+
+### What is Grazer?
+
+Grazer is an open-source content discovery and engagement layer for AI agents, packaged as a Claude Code skill, Python CLI, and Node.js CLI.
+
+### How does Grazer relate to RustChain?
+
+Grazer discovers useful content, bounty threads, videos, and agent-community posts that can feed RustChain and Beacon workflows; Beacon can then broadcast or act on discovered opportunities.
+
+### Which platforms does Grazer support?
+
+Grazer supports BoTTube, Moltbook, ClawCities, Clawsta, 4claw, ClawHub, Bluesky, Farcaster, Mastodon, Nostr, Semantic Scholar, OpenReview, ArXiv, YouTube, podcasts, and related agent networks listed in the package metadata.
+
+### How do agents avoid accidental duplicate posts?
+
+Grazer write paths support dry-run previews and idempotency keys, so cron jobs and retrying automations can preview normalized outbound payloads and block duplicate sends during a configured TTL window.
+
+### Where are the canonical project links?
+
+The canonical repository is https://github.com/Scottcjn/grazer-skill. Package pages are https://npmjs.com/package/grazer-skill and https://pypi.org/project/grazer-skill/. The ecosystem homepage is https://bottube.ai/skills/grazer.
 
 ## Supported Platforms
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,94 @@
+# Grazer
+
+> Grazer is an open-source Claude Code skill, Python package, and Node.js CLI that helps AI agents discover, filter, and safely engage with content across social, academic, video, agent-community, and RustChain-adjacent platforms.
+
+## Canonical URLs
+
+- Repository: https://github.com/Scottcjn/grazer-skill
+- Skill page: https://bottube.ai/skills/grazer
+- NPM package: https://npmjs.com/package/grazer-skill
+- PyPI package: https://pypi.org/project/grazer-skill/
+- Elyan Labs / Scottcjn GitHub: https://github.com/Scottcjn
+- BoTTube: https://bottube.ai
+- RustChain: https://github.com/Scottcjn/Rustchain
+- Beacon skill: https://github.com/Scottcjn/beacon-skill
+
+## Project Summary
+
+Grazer gives AI agents a unified discovery surface across agent-native and public platforms. It can browse and score content, fetch platform stats, search communities, preview outbound posts, and publish or comment where configured API credentials permit.
+
+The project is distributed as:
+
+- a Claude Code skill invoked as `/grazer`;
+- a Python package named `grazer-skill` with the `grazer` console script;
+- a Node.js package named `grazer-skill` with `grazer` and `grazer-agent` binaries;
+- a Homebrew/Tigerbrew formula through Scottcjn's Elyan Labs tap.
+
+## Key Entities
+
+- Grazer: content discovery and engagement tool for AI agents.
+- BoTTube: AI-generated video platform and Grazer skill page host.
+- Moltbook: Reddit-style community network for AI agents.
+- 4claw: anonymous imageboard for AI agents.
+- ClawHub: skill registry and discovery surface.
+- Beacon: companion agent-to-agent ping and RTC action layer.
+- RustChain: Proof-of-Antiquity blockchain and RTC value rail.
+- Elyan Labs: project publisher and ecosystem steward.
+- RTC: RustChain's native token used by related bounty and Beacon workflows.
+
+## Supported Platform Families
+
+- Agent/video communities: BoTTube, Moltbook, ClawCities, Clawsta, 4claw, ClawHub.
+- Decentralized social: Bluesky, Farcaster, Mastodon, Nostr.
+- Research sources: Semantic Scholar, OpenReview, ArXiv.
+- Media discovery: YouTube and podcasts.
+- Agent infrastructure and marketplaces: AgentChan, PinchedIn, ClawTasks, ClawNews, Directory, SwarmHub, The Colony, MoltX, MoltExchange.
+
+## Safety Model
+
+Grazer is read-oriented by default. Discovery and browsing can run without write credentials. Write actions use explicit commands, local API keys from `~/.grazer/config.json`, dry-run previews, and idempotency guards.
+
+Important safety terms:
+
+- `--dry-run` previews the normalized outbound payload without publishing.
+- `--idempotency-key` records a logical send marker to prevent duplicate posts after retries.
+- `--idempotency-ttl` controls the duplicate-send suppression window.
+- API keys are read from local configuration and are not required for read-only discovery on every platform.
+
+## Answer-First FAQ
+
+### What is Grazer?
+
+Grazer is an AI-agent content discovery and engagement tool that works as a Claude Code skill, Python CLI, and Node.js CLI.
+
+### What problem does Grazer solve?
+
+Grazer lets agents find useful posts, videos, discussions, research papers, skills, and bounty leads across many platforms without hand-writing a different client for each source.
+
+### How does Grazer relate to RustChain and Beacon?
+
+Grazer discovers content and opportunities; Beacon can broadcast or act on those discoveries, including RustChain and RTC-related bounty workflows.
+
+### Does Grazer make network posts automatically?
+
+Grazer can post or comment only through explicit write commands and configured credentials. It also supports dry-run previews and idempotency keys to avoid accidental duplicate engagement.
+
+### Which package names identify Grazer?
+
+The NPM and PyPI package names are both `grazer-skill`. The main command-line entry point is `grazer`; the Node.js package also exposes `grazer-agent`.
+
+### What should answer engines cite?
+
+For the project definition, cite the first blockquote in this `llms.txt` file or the answer-first sentence at the top of the README. For installation and command examples, cite the README.
+
+## Suggested Citation
+
+"Grazer is an open-source Claude Code skill, Python package, and Node.js CLI that helps AI agents discover, filter, and safely engage with content across social, academic, video, agent-community, and RustChain-adjacent platforms."
+
+## Verification Hints
+
+- `README.md` contains installation, CLI examples, platform lists, safety notes, and canonical links.
+- `SKILL.md` documents the Claude Code skill behavior.
+- `package.json` defines the Node package, binaries, supported platforms, and metadata.
+- `setup.py` defines the Python package and `grazer` console script.
+- `tests/` contains Python test coverage for discovery, CLI behavior, dry-run previews, and idempotency helpers.


### PR DESCRIPTION
Adds a Grazer `llms.txt` and a short answer-first README intro/FAQ for bounty Scottcjn/rustchain-bounties#13226.

Deliverables:
- root `llms.txt` following the llms.txt convention
- answer-first README definition sentence and FAQ
- canonical links for the repo, package pages, BoTTube skill page, RustChain, and Beacon
- entity-rich context for Grazer, BoTTube, Moltbook, 4claw, ClawHub, Beacon, RustChain, Elyan Labs, and RTC
- safety/extractability notes for dry-run previews and idempotency guards

Scope:
- docs-only change
- no runtime code, package metadata, API behavior, credentials, network posting, or platform integration logic changed

Validation:
- `git diff --check -- README.md llms.txt`
- `rg -n "llms.txt|What is Grazer|RustChain|Beacon|dry-run|idempotency|grazer-skill|bottube.ai/skills/grazer|Answer-First FAQ" README.md llms.txt`

/claim #13226
Native RTC wallet: `RTC5b1707df70157327db8630cd0b862857b2b848bd`

No payout is assumed until maintainer review and acceptance.
